### PR TITLE
 feat: warn on unmatched LCOV paths, nextest, mutation hardening

### DIFF
--- a/.cargo-mutants.toml
+++ b/.cargo-mutants.toml
@@ -1,0 +1,16 @@
+test_tool = "nextest"
+jobs = 4
+timeout = 60
+
+# Prevent RUSTFLAGS="-D warnings" (set in CI) from failing mutants on warnings
+# rather than on actual test failures — otherwise results are unreliable.
+cap_lints = true
+
+# Enable built-in skip patterns (e.g. with_capacity).
+skip_calls_defaults = true
+
+# No point mutating pure output/logging calls — they don't affect logic.
+skip_calls = ["eprintln!", "write!", "writeln!"]
+
+# Don't mutate integration test files — only source logic matters.
+exclude_globs = ["tests/**/*.rs"]

--- a/.cargo-mutants.toml
+++ b/.cargo-mutants.toml
@@ -1,5 +1,6 @@
 test_tool = "nextest"
 jobs = 4
+profile = "mutants"
 timeout = 60
 
 # Prevent RUSTFLAGS="-D warnings" (set in CI) from failing mutants on warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants,cargo-nextest
-      - name: Run mutation tests
+      - name: Run mutation tests (changed files only, PRs)
+        if: github.event_name == 'pull_request'
+        run: |
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'src/*.rs' 2>/dev/null || true)
+          if [ -z "$files" ]; then
+            echo "No changed src/*.rs files — skipping mutants."
+            exit 0
+          fi
+          echo "Running mutants on: $files"
+          cargo mutants $(echo "$files" | sed 's/^/--file /' | tr '\n' ' ')
+      - name: Run mutation tests (full, main)
+        if: github.event_name == 'push'
         run: cargo mutants
       - name: Upload mutants output
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --all-targets
+      - uses: taiki-e/install-action@cargo-nextest
       - name: Test
-        run: cargo test --all-targets
+        run: cargo nextest run --all-targets
       - name: Doc tests
         run: cargo test --doc
 
@@ -49,10 +48,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
-      - name: Build (MSRV)
-        run: cargo build --all-targets
+      - uses: taiki-e/install-action@cargo-nextest
       - name: Test (MSRV)
-        run: cargo test --all-targets
+        run: cargo nextest run --all-targets
+      - name: Doc tests (MSRV)
+        run: cargo test --doc
 
   audit:
     name: Security audit
@@ -74,9 +74,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,cargo-nextest
       - name: Run mutation tests
-        run: cargo mutants --timeout 60
+        run: cargo mutants
       - name: Upload mutants output
         if: always()
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Specs (THE LAW)
+
+All feature specs live in `specs/`. They are written in Gherkin style (Given/When/Then).
+
+- **Never modify a spec file without explicit permission from the user.**
+- When implementing a feature, treat its spec as the acceptance criteria.
+- When a spec needs to change (scope change, new edge case), propose the change and wait for approval before editing the file.
+
 ## Before committing
 
 Always run `just dev` before any commit. It runs fmt, clippy, and tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ pkg-fmt = "zip"
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+[profile.mutants]
+inherits = "dev"
+debug = 0

--- a/Justfile
+++ b/Justfile
@@ -30,6 +30,28 @@ dogfood:
 
 dev: fmt lint test dogfood
 
+# Mutation tests for a specific file: just mutants src/delta.rs
+mutants FILE:
+    cargo mutants --file {{FILE}}
+
 # Full validation including mutation tests (slow)
 dev-full: dev
     cargo mutants
+
+# Mutation tests only on files changed vs HEAD (uncommitted) or last commit
+dev-mutants-diff: dev
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # First: uncommitted changes (staged + unstaged)
+    files=$(git diff --name-only HEAD -- 'src/*.rs' 2>/dev/null || true)
+    # Fallback: files changed in the last commit
+    if [ -z "$files" ]; then
+        files=$(git diff --name-only HEAD~1 HEAD -- 'src/*.rs' 2>/dev/null || true)
+    fi
+    if [ -z "$files" ]; then
+        echo "No changed src/*.rs files — running all mutants"
+        cargo mutants
+    else
+        echo "Running mutants on: $files"
+        cargo mutants $(echo "$files" | sed 's/^/--file /' | tr '\n' ' ')
+    fi

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ default:
 
 # Run all tests
 test:
-    cargo test --all-targets
+    cargo nextest run --all-targets
     cargo test --doc
 
 # Apply formatting
@@ -20,7 +20,7 @@ lint:
 check:
     cargo check --all-targets
 
-# Run all CI checks locally
+# Run all CI checks locally (requires cargo-nextest: cargo binstall cargo-nextest)
 ci: lint test
 
 # Dogfood: score cargo-crap against itself (requires cargo-llvm-cov)
@@ -29,3 +29,7 @@ dogfood:
     cargo run --release -- --lcov lcov.info --path src --threshold 15 --fail-above
 
 dev: fmt lint test dogfood
+
+# Full validation including mutation tests (slow)
+dev-full: dev
+    cargo mutants

--- a/specs/02-json-version-field.md
+++ b/specs/02-json-version-field.md
@@ -1,0 +1,50 @@
+# Spec 02 — Version field in JSON output
+
+**Status:** Pending  
+**Effort:** Low  
+**Module:** `src/report.rs`
+
+## Context
+
+Downstream tools that consume `cargo crap --format json` have no way to detect
+when the output schema changes between releases. A top-level `version` field lets
+consumers guard against breaking changes.
+
+---
+
+## Acceptance Tests
+
+### Scenario: JSON output contains a version field
+
+```
+Given a Rust project with an LCOV file
+When  I run `cargo crap --format json`
+Then  the output is a JSON object (not a bare array)
+And   it contains a top-level "version" key
+And   the value of "version" matches the running crate version (e.g. "0.0.2")
+And   it contains a top-level "entries" key holding the function array
+```
+
+### Scenario: Version field survives --output to file
+
+```
+Given I run `cargo crap --format json --output out.json`
+When  I read out.json
+Then  the file contains the "version" field at the top level
+```
+
+### Scenario: Baseline loading is unaffected by version field
+
+```
+Given a JSON file produced by a previous run that contains a "version" field
+When  I pass it as `--baseline`
+Then  cargo-crap loads it successfully without error
+```
+
+### Scenario: JSON schema is still valid after the wrapper object
+
+```
+Given the wrapped JSON output { "version": "...", "entries": [...] }
+When  I validate it against the published JSON schema (spec 03)
+Then  validation passes
+```

--- a/specs/03-json-schema.md
+++ b/specs/03-json-schema.md
@@ -1,0 +1,61 @@
+# Spec 03 — Published JSON Schema
+
+**Status:** Pending  
+**Effort:** Low  
+**Depends on:** Spec 02 (version wrapper object)
+
+## Context
+
+Without a published schema, IDE plugins, dashboards, and custom CI scripts that
+consume `--format json` output have no authoritative reference to validate
+against or generate types from.
+
+---
+
+## Acceptance Tests
+
+### Scenario: JSON output includes a $schema key
+
+```
+Given I run `cargo crap --format json`
+Then  the top-level JSON object contains a "$schema" key
+And   the value is a stable HTTPS URL to the published schema
+```
+
+### Scenario: Published schema validates actual output
+
+```
+Given the schema at the URL referenced by "$schema"
+And   the JSON produced by `cargo crap --format json` against a real project
+When  I validate the JSON against the schema
+Then  validation passes with no errors
+```
+
+### Scenario: Published schema validates an empty entries list
+
+```
+Given a project with all functions excluded via --exclude
+When  I run `cargo crap --format json`
+Then  the output (with an empty "entries" array) still validates against the schema
+```
+
+### Scenario: Schema documents every field of a CrapEntry
+
+```
+Given the published schema
+Then  it describes the following fields for each entry:
+      - file (string, path)
+      - function (string)
+      - line (integer, >= 1)
+      - cyclomatic (number, >= 1)
+      - coverage (number 0–100, or null)
+      - crap (number, >= 1)
+```
+
+### Scenario: Delta mode output validates against a separate schema
+
+```
+Given I run `cargo crap --format json --baseline baseline.json`
+Then  the output validates against a delta-specific schema
+And   each entry additionally contains: baseline_crap, delta, status fields
+```

--- a/specs/04-jobs-flag.md
+++ b/specs/04-jobs-flag.md
@@ -1,0 +1,58 @@
+# Spec 04 — --jobs N flag for parallel analysis
+
+**Status:** Pending  
+**Effort:** Low  
+**Module:** `src/complexity.rs` (`analyze_tree`), `src/main.rs`
+
+## Context
+
+`analyze_tree` uses the default rayon global thread pool with no way to cap it.
+In memory-constrained CI/Docker environments this can cause OOM kills or resource
+contention. `--jobs N` lets operators bound the parallelism explicitly.
+
+---
+
+## Acceptance Tests
+
+### Scenario: --jobs 1 forces single-threaded analysis
+
+```
+Given a Rust project
+When  I run `cargo crap --jobs 1`
+Then  the command exits successfully
+And   output is identical to a run without --jobs
+```
+
+### Scenario: --jobs 4 completes successfully
+
+```
+Given a Rust project
+When  I run `cargo crap --jobs 4`
+Then  the command exits successfully
+And   results are identical to a run without --jobs
+```
+
+### Scenario: --jobs 0 is rejected
+
+```
+Given I run `cargo crap --jobs 0`
+Then  the command exits with a non-zero status
+And   stderr contains an error about invalid job count
+```
+
+### Scenario: --jobs configurable via .cargo-crap.toml
+
+```
+Given a .cargo-crap.toml containing:
+      jobs = 2
+When  I run `cargo crap` without --jobs
+Then  analysis uses at most 2 threads
+```
+
+### Scenario: CLI --jobs overrides config file
+
+```
+Given a .cargo-crap.toml containing jobs = 2
+When  I run `cargo crap --jobs 8`
+Then  analysis uses at most 8 threads
+```

--- a/specs/05-per-crate-rollup.md
+++ b/specs/05-per-crate-rollup.md
@@ -1,0 +1,61 @@
+# Spec 05 — Per-crate rollup in --workspace
+
+**Status:** Pending  
+**Effort:** Medium  
+**Module:** `src/report.rs`, `src/main.rs`
+
+## Context
+
+`--workspace` merges all crates into a single flat function list. In a monorepo
+with 20+ crates, teams need a high-level view: which crates are the worst
+offenders before drilling into individual functions.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Workspace human output includes per-crate summary table
+
+```
+Given a Cargo workspace with at least two member crates
+And   an LCOV file covering the workspace
+When  I run `cargo crap --workspace --lcov lcov.info`
+Then  the output contains a "Per-crate summary" section
+And   each crate appears as a row with: crate name, total functions, crappy count
+And   the per-function table follows as usual
+```
+
+### Scenario: Single-crate project shows no per-crate section
+
+```
+Given a single-crate Cargo project (not a workspace)
+When  I run `cargo crap --lcov lcov.info`
+Then  the output does not contain a "Per-crate summary" section
+```
+
+### Scenario: --summary flag shows only the crate-level table
+
+```
+Given a Cargo workspace
+When  I run `cargo crap --workspace --lcov lcov.info --summary`
+Then  the output contains the per-crate summary
+And   does not contain the per-function table
+```
+
+### Scenario: JSON output includes a crate field on each entry
+
+```
+Given a Cargo workspace
+When  I run `cargo crap --workspace --format json`
+Then  each entry in the JSON array contains a "crate" field
+And   the value is the crate name as declared in its Cargo.toml
+```
+
+### Scenario: --fail-above checks per-crate crappy count
+
+```
+Given a workspace where crate "alpha" has 3 crappy functions
+And   crate "beta" has 0 crappy functions
+When  I run `cargo crap --workspace --fail-above`
+Then  the command exits with code 1
+```

--- a/specs/06-allow-file-patterns.md
+++ b/specs/06-allow-file-patterns.md
@@ -1,0 +1,64 @@
+# Spec 06 — File-pattern suppressions in --allow
+
+**Status:** Pending  
+**Effort:** Medium  
+**Module:** `src/main.rs` (`apply_filters`)
+
+## Context
+
+`--allow` currently only matches function names. To suppress generated code or
+test helpers without excluding them from complexity analysis entirely (which
+`--exclude` does at walk time), users need to match by file path. Today they must
+use `--exclude` which also skips the files from CRAP scoring entirely.
+
+---
+
+## Acceptance Tests
+
+### Scenario: --allow with file glob suppresses matching functions
+
+```
+Given a project with functions in src/generated/mod.rs
+When  I run `cargo crap --allow 'src/generated/**'`
+Then  functions in src/generated/ do not appear in the output
+And   functions in other files are still shown
+```
+
+### Scenario: --allow file glob and function name pattern coexist
+
+```
+Given a project
+When  I run `cargo crap --allow 'src/generated/**' --allow 'my_helper'`
+Then  functions in src/generated/ are suppressed
+And   any function named my_helper is also suppressed
+```
+
+### Scenario: --allow file glob does not affect --fail-above count
+
+```
+Given a project where only suppressed files contain crappy functions
+When  I run `cargo crap --allow 'src/generated/**' --fail-above`
+Then  the command exits with code 0
+```
+
+### Scenario: File pattern in .cargo-crap.toml is respected
+
+```
+Given a .cargo-crap.toml containing:
+      allow = ["tests/**", "benches/**"]
+When  I run `cargo crap`
+Then  functions in tests/ and benches/ are not shown in the output
+```
+
+### Scenario: --allow file glob is distinct from --exclude
+
+```
+Given a file src/generated/foo.rs with complex functions
+When  I run `cargo crap --allow 'src/generated/**'`
+Then  the file is still walked and analyzed (complexity is computed)
+But   the functions do not appear in the report output
+```
+
+> Note: `--exclude` skips files at walk time (no analysis at all).
+> `--allow` (file pattern) analyzes but suppresses from output.
+> These are intentionally different.

--- a/specs/07-sarif-output.md
+++ b/specs/07-sarif-output.md
@@ -1,0 +1,72 @@
+# Spec 07 — SARIF output format
+
+**Status:** Pending  
+**Effort:** Medium  
+**Module:** `src/report.rs`
+
+## Context
+
+SARIF (Static Analysis Results Interchange Format) is consumed by GitHub's
+Security tab, rust-analyzer, VS Code, and many CI tools. Adding `--format sarif`
+gives cargo-crap first-class integration with the broader static analysis
+ecosystem without any extra tooling.
+
+---
+
+## Acceptance Tests
+
+### Scenario: --format sarif produces valid SARIF 2.1.0 JSON
+
+```
+Given a Rust project with crappy functions
+When  I run `cargo crap --format sarif`
+Then  the output is valid JSON
+And   it conforms to the SARIF 2.1.0 schema
+And   the "$schema" field references the SARIF 2.1.0 schema URL
+And   the "version" field is "2.1.0"
+```
+
+### Scenario: Each crappy function appears as a SARIF result
+
+```
+Given a function "crappy" in src/lib.rs at line 24 with CRAP score 156.0
+And   the threshold is 30
+When  I run `cargo crap --format sarif`
+Then  the SARIF output contains a result for "crappy"
+And   the result's level is "warning"
+And   the location points to src/lib.rs line 24
+And   the message includes the CRAP score
+```
+
+### Scenario: Clean functions do not appear as SARIF results
+
+```
+Given a function with CRAP score below the threshold
+When  I run `cargo crap --format sarif`
+Then  that function does not appear in the SARIF results array
+```
+
+### Scenario: SARIF output is uploadable to GitHub code scanning
+
+```
+Given a SARIF file produced by `cargo crap --format sarif --output results.sarif`
+When  uploaded via `gh code-scanning upload-results --sarif results.sarif`
+Then  crappy functions appear in the repository's Security → Code scanning tab
+```
+
+### Scenario: --fail-above still works with SARIF format
+
+```
+Given a project with crappy functions
+When  I run `cargo crap --format sarif --fail-above`
+Then  the command exits with code 1
+And   the SARIF output is written to stdout (or --output file)
+```
+
+### Scenario: Empty results produce a valid SARIF document
+
+```
+Given a project with no functions exceeding the threshold
+When  I run `cargo crap --format sarif`
+Then  the output is valid SARIF with an empty results array
+```

--- a/specs/08-tunable-epsilon.md
+++ b/specs/08-tunable-epsilon.md
@@ -1,0 +1,81 @@
+# Spec 08 — Tunable --epsilon for regression detection
+
+**Status:** Pending  
+**Effort:** Low  
+**Module:** `src/delta.rs`, `src/main.rs`
+
+## Context
+
+The regression epsilon (currently hardcoded at `0.01` in `delta.rs:24`) controls
+how much a CRAP score must increase before it counts as a regression. Teams with
+noisy coverage (e.g. flaky integration tests) need a larger tolerance; strict
+teams may want `0.0`.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Default epsilon of 0.01 — delta below epsilon is Unchanged
+
+```
+Given a baseline where "foo" has CRAP score 10.000
+And   the current run shows "foo" with CRAP score 10.005  (delta = 0.005)
+When  I run `cargo crap --baseline baseline.json --fail-regression`
+Then  "foo" is reported as Unchanged
+And   the command exits with code 0
+```
+
+### Scenario: Default epsilon of 0.01 — delta above epsilon is Regressed
+
+```
+Given a baseline where "foo" has CRAP score 10.000
+And   the current run shows "foo" with CRAP score 10.020  (delta = 0.020)
+When  I run `cargo crap --baseline baseline.json --fail-regression`
+Then  "foo" is reported as Regressed
+And   the command exits with code 1
+```
+
+### Scenario: --epsilon 0.5 tolerates larger drift
+
+```
+Given a baseline where "foo" has CRAP score 10.000
+And   the current run shows "foo" with CRAP score 10.4  (delta = 0.4)
+When  I run `cargo crap --baseline baseline.json --epsilon 0.5 --fail-regression`
+Then  "foo" is reported as Unchanged
+And   the command exits with code 0
+```
+
+### Scenario: --epsilon 0.0 catches any score increase
+
+```
+Given a baseline where "foo" has CRAP score 10.000
+And   the current run shows "foo" with CRAP score 10.001  (delta = 0.001)
+When  I run `cargo crap --baseline baseline.json --epsilon 0.0 --fail-regression`
+Then  "foo" is reported as Regressed
+And   the command exits with code 1
+```
+
+### Scenario: Negative --epsilon is rejected
+
+```
+Given I run `cargo crap --baseline baseline.json --epsilon -1.0`
+Then  the command exits with a non-zero status
+And   stderr contains an error about invalid epsilon value
+```
+
+### Scenario: --epsilon configurable in .cargo-crap.toml
+
+```
+Given a .cargo-crap.toml containing:
+      epsilon = 0.5
+When  I run `cargo crap --baseline baseline.json`
+Then  0.5 is used as the regression threshold
+```
+
+### Scenario: CLI --epsilon overrides config file
+
+```
+Given a .cargo-crap.toml containing epsilon = 0.5
+When  I run `cargo crap --baseline baseline.json --epsilon 0.0`
+Then  0.0 is used as the regression threshold
+```

--- a/specs/09-cargo-expand-integration.md
+++ b/specs/09-cargo-expand-integration.md
@@ -1,0 +1,59 @@
+# Spec 09 — cargo expand integration (--expanded)
+
+**Status:** Pending  
+**Effort:** High  
+**Module:** `src/complexity.rs`
+
+## Context
+
+`syn` parses the source as-written. Proc-macro generated code (derive handlers,
+builder patterns, `thiserror` impls) is invisible — their complexity is simply
+not counted. `--expanded` runs `cargo expand` first and analyzes the expanded
+output, giving accurate CC for macro-heavy codebases.
+
+---
+
+## Acceptance Tests
+
+### Scenario: --expanded reveals complexity from derive macros
+
+```
+Given a struct with #[derive(Builder)] that generates 10+ methods
+And   without --expanded those methods do not appear in the output
+When  I run `cargo crap --expanded`
+Then  the generated builder methods appear in the output with their CRAP scores
+```
+
+### Scenario: --expanded requires cargo-expand to be installed
+
+```
+Given cargo-expand is not installed on the system
+When  I run `cargo crap --expanded`
+Then  the command exits with a non-zero status
+And   stderr suggests running `cargo install cargo-expand`
+```
+
+### Scenario: Without --expanded, macro-generated code is not shown
+
+```
+Given a struct with #[derive(Debug, Clone, PartialEq)]
+When  I run `cargo crap` without --expanded
+Then  the derived Debug/Clone/PartialEq impls do not appear in the output
+```
+
+### Scenario: --expanded and --lcov work together
+
+```
+Given a project using proc-macros
+And   an LCOV file generated from the expanded build
+When  I run `cargo crap --expanded --lcov lcov.info`
+Then  coverage data is matched to expanded function spans
+```
+
+### Scenario: --expanded is slower and warns the user
+
+```
+Given a large project
+When  I run `cargo crap --expanded`
+Then  a progress indicator or note indicates that expansion may take extra time
+```

--- a/specs/10-incremental-cache.md
+++ b/specs/10-incremental-cache.md
@@ -1,0 +1,73 @@
+# Spec 10 — Incremental analysis cache
+
+**Status:** Pending  
+**Effort:** High  
+**Module:** `src/complexity.rs`
+
+## Context
+
+Every run re-parses all source files via `syn`, even if nothing changed. For a
+large repo with hundreds of files, this adds unnecessary latency. A cache keyed
+on file path + modification time (or content hash) makes repeat runs near-instant
+for the common case of analyzing a small change.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Second run on unchanged files uses the cache
+
+```
+Given a large Rust project
+And   I have run `cargo crap` once (cache is populated)
+When  I run `cargo crap` again without modifying any source files
+Then  the command completes faster than the first run
+And   the results are byte-for-byte identical to the first run
+```
+
+### Scenario: Cache is invalidated when a file is modified
+
+```
+Given a cached analysis run
+When  I modify src/lib.rs (e.g. add a branch)
+And   run `cargo crap` again
+Then  src/lib.rs is re-analyzed and its new complexity is reflected
+And   other unchanged files still use the cached results
+```
+
+### Scenario: Cache is invalidated when a file is deleted
+
+```
+Given a cached result that includes src/old.rs
+When  src/old.rs is deleted
+And   I run `cargo crap` again
+Then  src/old.rs does not appear in the output
+And   no stale cache entry causes an error
+```
+
+### Scenario: --no-cache bypasses the cache entirely
+
+```
+Given a populated cache
+When  I run `cargo crap --no-cache`
+Then  all files are re-analyzed from scratch
+And   the cache is not read or written
+```
+
+### Scenario: Cache survives across working directory changes
+
+```
+Given a populated cache stored in the project's target directory
+When  I run `cargo crap` from a different working directory (e.g. a subdirectory)
+Then  the cache is still found and used
+```
+
+### Scenario: Corrupted cache file is silently ignored
+
+```
+Given a cache file that has been corrupted (invalid bytes)
+When  I run `cargo crap`
+Then  the command falls back to a full re-analysis
+And   no error is shown to the user
+And   the cache is rebuilt
+```

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -280,4 +280,34 @@ mod tests {
         assert!(report.entries.iter().all(|e| e.status == DeltaStatus::New));
         assert!(report.removed.is_empty());
     }
+
+    #[test]
+    fn backslash_paths_match_forward_slash_baseline() {
+        // Kills: replace path_key -> String with String::new() or "xyzzy".into()
+        // Baseline was saved on Linux (forward slashes); current run is on
+        // Windows (backslashes). path_key must normalize them to the same key.
+        let current = vec![CrapEntry {
+            file: PathBuf::from("tests\\fixtures\\src\\lib.rs"),
+            function: "foo".into(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap: 10.0,
+        }];
+        let baseline = vec![CrapEntry {
+            file: PathBuf::from("tests/fixtures/src/lib.rs"),
+            function: "foo".into(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap: 5.0,
+        }];
+        let report = compute_delta(&current, &baseline);
+        assert_eq!(
+            report.entries[0].status,
+            DeltaStatus::Regressed,
+            "backslash path must match its forward-slash baseline counterpart"
+        );
+        assert!(report.removed.is_empty(), "no entries should be removed");
+    }
 }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -282,10 +282,45 @@ mod tests {
     }
 
     #[test]
-    fn backslash_paths_match_forward_slash_baseline() {
+    fn functions_in_different_files_are_not_matched() {
         // Kills: replace path_key -> String with String::new() or "xyzzy".into()
-        // Baseline was saved on Linux (forward slashes); current run is on
-        // Windows (backslashes). path_key must normalize them to the same key.
+        //
+        // If path_key collapses to a constant, ("", "foo") in current matches
+        // ("", "foo") in baseline regardless of file — "foo" would appear as
+        // Unchanged instead of New, and the baseline entry would not be Removed.
+        let current = vec![CrapEntry {
+            file: PathBuf::from("src/lib.rs"),
+            function: "foo".into(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap: 5.0,
+        }];
+        let baseline = vec![CrapEntry {
+            file: PathBuf::from("src/main.rs"), // different file, same function name
+            function: "foo".into(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap: 5.0,
+        }];
+        let report = compute_delta(&current, &baseline);
+        assert_eq!(
+            report.entries[0].status,
+            DeltaStatus::New,
+            "foo in src/lib.rs must not match foo in src/main.rs"
+        );
+        assert_eq!(
+            report.removed.len(),
+            1,
+            "baseline foo must appear as removed"
+        );
+    }
+
+    #[test]
+    fn backslash_paths_match_forward_slash_baseline() {
+        // Baseline saved on Linux (forward slashes); current run on Windows
+        // (backslashes). path_key must normalize both to the same key.
         let current = vec![CrapEntry {
             file: PathBuf::from("tests\\fixtures\\src\\lib.rs"),
             function: "foo".into(),
@@ -308,6 +343,6 @@ mod tests {
             DeltaStatus::Regressed,
             "backslash path must match its forward-slash baseline counterpart"
         );
-        assert!(report.removed.is_empty(), "no entries should be removed");
+        assert!(report.removed.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //!
 //! // 3. Join complexity with coverage. Functions with no coverage data are
 //! //    treated as 0% covered (the pessimistic default, safest for CI gates).
-//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic);
+//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
 //! // 4. Render the human-readable table to stdout.
 //! render(&entries, DEFAULT_THRESHOLD, Format::Human, &mut io::stdout())?;
@@ -90,7 +90,7 @@
 //!     &[] as &[&str],
 //! )?;
 //! let cov = coverage::parse_lcov(std::path::Path::new("lcov.info"))?;
-//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic);
+//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
 //! let threshold = 30.0_f64;
 //! let crappy: Vec<_> = entries.iter().filter(|e| e.crap > threshold).collect();
@@ -125,7 +125,7 @@
 //!     &[] as &[&str],
 //! )?;
 //! let cov = coverage::parse_lcov(std::path::Path::new("lcov.info"))?;
-//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic);
+//! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
 //! // Load baseline saved by a previous `--format json --output baseline.json` run.
 //! let baseline = load_baseline(std::path::Path::new("baseline.json"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,6 +290,26 @@ fn workspace_roots() -> Result<Vec<PathBuf>> {
     Ok(roots)
 }
 
+/// Emit a stderr warning listing source files with no LCOV match.
+///
+/// `unmapped_files` is empty when no `--lcov` was given (merge guarantees this),
+/// so the call is always safe and the guard lives here rather than at the call site.
+fn warn_unmapped(files: &[std::path::PathBuf]) {
+    if files.is_empty() {
+        return;
+    }
+    let n = files.len();
+    eprintln!(
+        "warning: {} source file{} had no matching entry in the LCOV report \
+         — verify your --lcov path or coverage tool configuration:",
+        n,
+        if n == 1 { "" } else { "s" },
+    );
+    for f in files {
+        eprintln!("  {}", f.display());
+    }
+}
+
 /// Validate argument combinations that clap cannot express as declarative rules.
 fn validate_args(cli: &Cli) -> Result<()> {
     if !cli.workspace && !cli.path.exists() {
@@ -369,7 +389,9 @@ fn main() -> Result<()> {
     pb.finish_and_clear();
 
     // --- Merge + filters ---
-    let mut entries = merge(fns, coverage, missing_policy);
+    let merge_result = merge(fns, coverage, missing_policy);
+    warn_unmapped(&merge_result.unmapped_files);
+    let mut entries = merge_result.entries;
     apply_filters(
         &mut entries,
         &effective_allow,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -27,7 +27,7 @@ use crate::complexity::FunctionComplexity;
 use crate::coverage::FileCoverage;
 use crate::score::crap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// One row in the final report.
@@ -58,14 +58,29 @@ pub enum MissingCoveragePolicy {
     Skip,
 }
 
-/// Merge complexity and coverage data into a sorted `Vec<CrapEntry>`
-/// (highest score first).
+/// Output of [`merge`]: the scored entries plus any source files that had no
+/// matching entry in the LCOV report.
+pub struct MergeResult {
+    /// CRAP entries sorted by score descending.
+    pub entries: Vec<CrapEntry>,
+    /// Source files for which no coverage data could be found in the LCOV
+    /// report. Only populated when a non-empty coverage map was provided.
+    /// Non-empty here is a strong signal of a path-matching problem.
+    pub unmapped_files: Vec<PathBuf>,
+}
+
+/// Merge complexity and coverage data into a sorted [`MergeResult`]
+/// (entries ranked highest score first).
 pub fn merge(
     complexity: Vec<FunctionComplexity>,
     coverage: HashMap<PathBuf, FileCoverage>,
     policy: MissingCoveragePolicy,
-) -> Vec<CrapEntry> {
+) -> MergeResult {
     let index = PathIndex::build(&coverage);
+    let has_coverage = !coverage.is_empty();
+
+    let mut mapped_files: HashSet<PathBuf> = HashSet::new();
+    let mut seen_files: HashSet<PathBuf> = HashSet::new();
 
     let mut entries: Vec<CrapEntry> = complexity
         .into_iter()
@@ -73,6 +88,13 @@ pub fn merge(
             let cov = index
                 .lookup(&fc.file)
                 .map(|cov_file| cov_file.coverage_in_span(fc.start_line, fc.end_line));
+
+            if has_coverage {
+                if cov.is_some() {
+                    mapped_files.insert(fc.file.clone());
+                }
+                seen_files.insert(fc.file.clone());
+            }
 
             let cov_for_scoring = match (cov, policy) {
                 (Some(c), _) => c,
@@ -98,7 +120,17 @@ pub fn merge(
             .partial_cmp(&a.crap)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    entries
+
+    let mut unmapped_files: Vec<PathBuf> = seen_files
+        .into_iter()
+        .filter(|f| !mapped_files.contains(f))
+        .collect();
+    unmapped_files.sort();
+
+    MergeResult {
+        entries,
+        unmapped_files,
+    }
 }
 
 /// A path lookup index that handles absolute-vs-relative mismatches between
@@ -264,13 +296,13 @@ mod tests {
                 cyclomatic: 10.0,
             },
         ];
-        let entries = merge(
+        let result = merge(
             complexity,
             HashMap::new(),
             MissingCoveragePolicy::Pessimistic,
         );
-        assert_eq!(entries[0].function, "hard");
-        assert_eq!(entries[1].function, "easy");
+        assert_eq!(result.entries[0].function, "hard");
+        assert_eq!(result.entries[1].function, "easy");
     }
 
     #[test]
@@ -282,8 +314,8 @@ mod tests {
             end_line: 5,
             cyclomatic: 3.0,
         }];
-        let entries = merge(complexity, HashMap::new(), MissingCoveragePolicy::Skip);
-        assert!(entries.is_empty());
+        let result = merge(complexity, HashMap::new(), MissingCoveragePolicy::Skip);
+        assert!(result.entries.is_empty());
     }
 
     #[test]
@@ -314,5 +346,54 @@ mod tests {
         // succeed via suffix match.
         let found = index.lookup(Path::new("/somewhere/else/src/lib.rs"));
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn unmapped_files_reported_when_lcov_provided() {
+        let mut cov_map = HashMap::new();
+        cov_map.insert(PathBuf::from("src/foo.rs"), cov_with(&[(1, 1)]));
+
+        let complexity = vec![
+            FunctionComplexity {
+                file: PathBuf::from("/project/src/foo.rs"),
+                name: "matched".into(),
+                start_line: 1,
+                end_line: 3,
+                cyclomatic: 1.0,
+            },
+            FunctionComplexity {
+                file: PathBuf::from("/project/src/bar.rs"),
+                name: "unmatched".into(),
+                start_line: 1,
+                end_line: 3,
+                cyclomatic: 1.0,
+            },
+        ];
+
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        assert_eq!(
+            result.unmapped_files,
+            vec![PathBuf::from("/project/src/bar.rs")]
+        );
+    }
+
+    #[test]
+    fn no_unmapped_files_when_no_lcov_provided() {
+        let complexity = vec![FunctionComplexity {
+            file: PathBuf::from("src/foo.rs"),
+            name: "foo".into(),
+            start_line: 1,
+            end_line: 3,
+            cyclomatic: 1.0,
+        }];
+        let result = merge(
+            complexity,
+            HashMap::new(),
+            MissingCoveragePolicy::Pessimistic,
+        );
+        assert!(
+            result.unmapped_files.is_empty(),
+            "no lcov → no unmapped warnings"
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1212,3 +1212,42 @@ fn markdown_clean_summary_says_none_exceed() {
         .success()
         .stdout(predicate::str::contains("none exceed CRAP threshold"));
 }
+
+// --- Unmapped file warnings ---
+
+#[test]
+fn unmatched_lcov_emits_warning_to_stderr() {
+    // When --lcov paths don't match the source tree, warn_unmapped must
+    // print a warning to stderr naming the unmatched files. This test kills
+    // the `replace warn_unmapped with ()` mutant.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lcov_path = dir.path().join("unmatched.lcov");
+    // Deliberately non-matching absolute path — nothing in the fixture src
+    // will suffix-match "/nonexistent/path/src/lib.rs".
+    std::fs::write(
+        &lcov_path,
+        "SF:/nonexistent/path/src/lib.rs\nDA:1,1\nend_of_record\n",
+    )
+    .expect("write lcov");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .assert()
+        .stderr(predicate::str::contains(
+            "had no matching entry in the LCOV report",
+        ));
+}
+
+#[test]
+fn no_warning_when_lcov_not_provided() {
+    // Without --lcov, warn_unmapped must stay silent.
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning:").not());
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -36,7 +36,7 @@ fn end_to_end_pipeline_produces_ranked_scores() {
     );
 
     // 3. Merge with pessimistic policy (matches what a CI gate would do).
-    let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic);
+    let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic).entries;
     assert!(!entries.is_empty(), "merge produced no entries");
 
     // 4. Verify ordering: crappy must outrank moderate must outrank trivial.
@@ -95,7 +95,7 @@ fn json_output_round_trips() {
     let complexity =
         complexity::analyze_tree(&root.join("src"), &[] as &[&str]).expect("analyze_tree");
     let coverage = coverage::parse_lcov(&root.join("lcov.info")).expect("parse_lcov");
-    let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic);
+    let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic).entries;
 
     let mut buf = Vec::new();
     cargo_crap::report::render(&entries, 30.0, cargo_crap::report::Format::Json, &mut buf)


### PR DESCRIPTION
  - Emit stderr warning when source files have no matching LCOV entry=
    (MergeResult.unmapped_files, warn_unmapped helper in main)                                                                                                                     
  - Bump MSRV 1.85 → 1.88 to match comfy-table 7.2.2 let-chain requirement                                                                                                         
  - Collapse nested if-let chains now stable at 1.88 (complexity, coverage, merge)                                                                                                 
  - Normalize path separators in delta join key — fixes Windows CI failures                                                                                                        
  - Drop version from release archive filenames for stable install URLs                                                                                                            
  - Update binstall metadata and README install instructions                                                                                                                       
  - Switch security audit to taiki-e/install-action + cargo audit                                                                                                                  
  - Migrate all tests to cargo nextest; keep cargo test --doc separately                                                                                                           
  - Add .cargo-mutants.toml: nextest, jobs=4, cap_lints, skip_calls, exclude_globs                                                                                                 
  - Add specs/ directory with Gherkin acceptance tests for features 02–10                                                                                                          
  - Fix two missed mutants: warn_unmapped (CLI test) and path_key (unit test)  