### PR TITLE
feat(pr-comment): clickable source links for Function and Location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,15 @@ jobs:
       # `always()` runs these steps even when the Regression check above
       # exits non-zero — that's exactly when we want the comment to land,
       # because it tells the reviewer *what* regressed.
+      # `pull_request.head.sha` is the actual commit users browse on the PR
+      # branch; `github.sha` on a pull_request event is the synthetic merge
+      # commit and won't resolve in `/blob/<sha>/...` URLs. Both vars are
+      # GitHub-managed (not user input) — safe to interpolate via env:.
       - name: Generate PR comment
         if: always() && github.event_name == 'pull_request'
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          COMMIT_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -f baseline/crap-current.json ] && grep -q '"version"' baseline/crap-current.json; then
             cargo run --release -- \
@@ -210,6 +217,8 @@ jobs:
               --exclude 'tests/fixtures/**' \
               --baseline baseline/crap-current.json \
               --format pr-comment \
+              --repo-url "$REPO_URL" \
+              --commit-ref "$COMMIT_REF" \
               --output crap-comment.md || true
           else
             cargo run --release -- \
@@ -217,6 +226,8 @@ jobs:
               --workspace \
               --exclude 'tests/fixtures/**' \
               --format pr-comment \
+              --repo-url "$REPO_URL" \
+              --commit-ref "$COMMIT_REF" \
               --output crap-comment.md || true
             printf '\n_No baseline available — showing absolute scores only._\n' >> crap-comment.md
           fi

--- a/specs/12-pr-comment-source-links.md
+++ b/specs/12-pr-comment-source-links.md
@@ -1,0 +1,253 @@
+# Spec 12 — Clickable source links in PR-comment / markdown output
+
+**Status:** Proposed
+**Effort:** Small
+**Module:** `src/main.rs`, `src/report.rs`, `.github/workflows/ci.yml`
+
+## Context
+
+The `pr-comment` and `markdown` renderers currently print the function name and
+its `file:line` as plain code spans:
+
+```
+| ✓ | 2.0 | NEW | 1 | — | `compile_schema` | `:160` |
+```
+
+Reviewers cannot jump from the comment to the source — they have to copy the
+function name, open the repo, and search. When the longest-common-prefix
+strips the file path away (single-file or single-entry runs), the Location
+cell collapses to bare `:160`, which is even less useful.
+
+This spec adds optional GitHub-aware source links. When the renderer is given
+a repository URL and a commit ref, it wraps both the Function name and the
+Location string in markdown links pointing at the file/line on GitHub:
+
+```
+| ✓ | 2.0 | NEW | 1 | — | [`compile_schema`](https://github.com/owner/repo/blob/<sha>/src/schema.rs#L160) | [`src/schema.rs:160`](https://github.com/owner/repo/blob/<sha>/src/schema.rs#L160) |
+```
+
+Behaviour is unchanged when the flags are absent — local runs with no GitHub
+context still produce the same output as today.
+
+---
+
+## Acceptance Tests
+
+### Scenario: No flags → no links (backwards compatible)
+
+```
+Given I run `cargo crap --format pr-comment` with neither --repo-url nor --commit-ref set
+And   no GITHUB_SERVER_URL / GITHUB_REPOSITORY / GITHUB_SHA env vars are present
+When  I read the output
+Then  no Function cell is wrapped in a markdown link
+And   no Location cell is wrapped in a markdown link
+```
+
+### Scenario: Both flags → Function and Location are links
+
+```
+Given I run `cargo crap --format pr-comment --repo-url https://github.com/owner/repo --commit-ref abc123`
+When  I read the output
+Then  every rendered Function cell has the form ``[`<name>`](<repo-url>/blob/<ref>/<path>#L<line>)``
+And   every rendered Location cell has the form ``[`<displayed-loc>`](<repo-url>/blob/<ref>/<path>#L<line>)``
+```
+
+### Scenario: Link URL uses the full original path, not the LCP-stripped display path
+
+```
+Given a single rendered entry whose Location text is stripped to `:160`
+And   the entry's full path is `src/schema.rs`
+When  the pr-comment renders with --repo-url X --commit-ref Y
+Then  the markdown link target is `X/blob/Y/src/schema.rs#L160`
+And   the visible link text is `:160` (display rule unchanged)
+```
+
+### Scenario: Trailing slash on --repo-url is normalized
+
+```
+Given --repo-url is `https://github.com/owner/repo/`
+When  the pr-comment renders
+Then  link targets contain exactly one `/blob/` separator (no `//blob/`)
+```
+
+### Scenario: Only one flag → no links
+
+```
+Given --repo-url is set but --commit-ref is not (or vice versa)
+When  the pr-comment renders
+Then  no markdown links are emitted (graceful fallback to plain code spans)
+```
+
+### Scenario: Defaults from GitHub Actions env vars
+
+```
+Given GITHUB_SERVER_URL=https://github.com, GITHUB_REPOSITORY=owner/repo, GITHUB_SHA=abc123 are set
+And   neither --repo-url nor --commit-ref is passed on the CLI
+When  I run `cargo crap --format pr-comment`
+Then  the renderer behaves as if `--repo-url https://github.com/owner/repo --commit-ref abc123` were passed
+```
+
+### Scenario: CLI flags override env vars
+
+```
+Given GITHUB_SHA=env_sha is set
+And   --commit-ref cli_sha is passed on the CLI
+When  the pr-comment renders
+Then  link targets use `cli_sha`, not `env_sha`
+```
+
+### Scenario: Removed entries do not get links
+
+```
+Given a baseline with a function that no longer exists on HEAD
+And   --repo-url and --commit-ref are set (pointing at HEAD)
+When  the pr-comment renders the `— N removed` section
+Then  the removed function name is not wrapped in a markdown link
+```
+
+### Scenario: Hot-spots and Improved sections also get links
+
+```
+Given --repo-url and --commit-ref are set
+When  the pr-comment renders Hot-spots and Improved sections
+Then  every Function cell in those sections is a markdown link
+And   every Location cell in those sections is a markdown link
+```
+
+### Scenario: Markdown format also emits links
+
+```
+Given --repo-url and --commit-ref are set
+When  I run `cargo crap --format markdown` (with or without --baseline)
+Then  Function and Location cells in the rendered table are markdown links
+```
+
+### Scenario: Other formats are unaffected
+
+```
+Given --repo-url and --commit-ref are set
+When  I run `cargo crap --format json` (or `human`, `github`)
+Then  no markdown links appear in the output
+And   the JSON envelope is unchanged
+```
+
+---
+
+## Implementation Notes
+
+### CLI surface (`src/main.rs`)
+
+Add two flags:
+
+```rust
+/// Base URL of the source-hosting repo (e.g. https://github.com/owner/repo).
+/// When combined with --commit-ref, Function and Location cells in
+/// `pr-comment` / `markdown` output become clickable links.
+#[arg(long, env = "CRAP_REPO_URL")]
+repo_url: Option<String>,
+
+/// Commit SHA or branch name to deep-link into.
+#[arg(long, env = "CRAP_COMMIT_REF")]
+commit_ref: Option<String>,
+```
+
+Defaults are resolved in `main` (not via clap `env`) because GitHub Actions
+exposes the repo as two separate vars (`GITHUB_SERVER_URL` +
+`GITHUB_REPOSITORY`) that need joining. Resolution order:
+
+1. CLI flag (if provided).
+2. `CRAP_REPO_URL` / `CRAP_COMMIT_REF` (an explicit override knob users can
+   set in their own CI).
+3. `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY` joined with a `/`, and
+   `GITHUB_SHA`.
+4. Otherwise `None` → no links.
+
+If exactly one of (`repo_url`, `commit_ref`) resolves to `Some`, treat the
+pair as `None` (links only render when both are present).
+
+### Renderer changes (`src/report.rs`)
+
+New struct passed alongside `threshold` into pr-comment / markdown renderers:
+
+```rust
+#[derive(Clone, Debug, Default)]
+pub struct SourceLinks {
+    pub repo_url: String, // normalized — no trailing slash
+    pub commit_ref: String,
+}
+
+impl SourceLinks {
+    pub fn new(repo_url: String, commit_ref: String) -> Self {
+        let trimmed = repo_url.trim_end_matches('/').to_string();
+        Self { repo_url: trimmed, commit_ref }
+    }
+
+    pub fn url_for(&self, file: &Path, line: u32) -> String {
+        format!("{}/blob/{}/{}#L{}",
+                self.repo_url, self.commit_ref, file.display(), line)
+    }
+}
+```
+
+Plumb `Option<&SourceLinks>` through:
+
+- `render_pr_comment`, `render_delta_pr_comment`
+- `render_markdown`, `render_delta_markdown`
+- The internal `write_pr_comment_row`, `write_pr_comment_abs_row`,
+  `write_markdown_entries_table`, `write_delta_entries_table` helpers
+- `write_pr_comment_improved_section`, `write_pr_comment_hot_spots_section`
+- **NOT** `write_pr_comment_removed_section` — those functions no longer
+  exist at the linked ref.
+
+Cell rendering helper:
+
+```rust
+fn linked(text: &str, links: Option<&SourceLinks>, file: &Path, line: u32) -> String {
+    match links {
+        Some(l) => format!("[{text}]({})", l.url_for(file, line)),
+        None    => text.to_string(),
+    }
+}
+```
+
+Apply to both the backtick-wrapped Function name and the backtick-wrapped
+`{loc}:{line}` cell.
+
+### Path used in the URL
+
+Always the **original** `entry.file` (a full or repo-relative path produced by
+the AST walk), never the LCP-stripped display string. The display string is a
+human-readable hint; the link must resolve in the repo.
+
+When `entry.file` is absolute, the link will only resolve if the absolute
+path is also a valid repo path, which it normally isn't. Local runs without
+flags don't produce links anyway, and CI runs `cargo crap` from the repo root
+so paths are repo-relative — covered by an integration test.
+
+### `Format::Json` / `Format::Github` / `Format::Human`
+
+Untouched. These renderers ignore `SourceLinks`.
+
+### CI changes (`.github/workflows/ci.yml`)
+
+In the **Generate PR comment** step add:
+
+```yaml
+--repo-url ${{ github.server_url }}/${{ github.repository }} \
+--commit-ref ${{ github.event.pull_request.head.sha }} \
+```
+
+`pull_request.head.sha` is preferred over `github.sha` (which on
+`pull_request` events is the merge-commit SHA — a synthetic ref users can't
+browse).
+
+### Why links on both Function and Location
+
+Function cell carries the most semantically clickable text; Location is what
+review eyes already track for "where is this?". Two link targets to the same
+URL is cheap (markdown-link characters) and removes any "click the name vs.
+click the path" friction.
+
+### Constants
+
+None. `SourceLinks` is plain data.

--- a/specs/12-pr-comment-source-links.md
+++ b/specs/12-pr-comment-source-links.md
@@ -52,14 +52,31 @@ Then  every rendered Function cell has the form ``[`<name>`](<repo-url>/blob/<re
 And   every rendered Location cell has the form ``[`<displayed-loc>`](<repo-url>/blob/<ref>/<path>#L<line>)``
 ```
 
-### Scenario: Link URL uses the full original path, not the LCP-stripped display path
+### Scenario: Link URL uses the LCP/CWD-stripped path so it resolves on GitHub
 
 ```
-Given a single rendered entry whose Location text is stripped to `:160`
-And   the entry's full path is `src/schema.rs`
-When  the pr-comment renders with --repo-url X --commit-ref Y
-Then  the markdown link target is `X/blob/Y/src/schema.rs#L160`
-And   the visible link text is `:160` (display rule unchanged)
+Given an entry whose AST-discovered file path is absolute (e.g.
+      `/home/runner/work/repo/repo/src/main.rs`) — typical for
+      `--workspace` runs where cargo metadata returns absolute paths
+And   the run's CWD is the repo root (`/home/runner/work/repo/repo`)
+And   --repo-url + --commit-ref are set
+When  the pr-comment renders
+Then  the markdown link target uses the path relative to that CWD/LCP
+      (e.g. `<repo-url>/blob/<ref>/src/main.rs#L<line>`)
+And   the URL contains exactly one `/blob/` separator (no `//blob/`)
+And   the URL contains no leading `/` between `<ref>/` and the path
+```
+
+### Scenario: Path that cannot be made repo-relative falls back to plain text
+
+```
+Given an entry whose path is NOT under CWD and shares no LCP with other
+      rendered entries (so prefix-stripping leaves it absolute)
+And   --repo-url + --commit-ref are set
+When  the pr-comment renders
+Then  the Function and Location cells are NOT wrapped in markdown links
+      (a `host/repo/blob/sha//abs/path` URL would 404)
+And   the row still renders with plain code spans
 ```
 
 ### Scenario: Trailing slash on --repo-url is normalized
@@ -215,14 +232,17 @@ Apply to both the backtick-wrapped Function name and the backtick-wrapped
 
 ### Path used in the URL
 
-Always the **original** `entry.file` (a full or repo-relative path produced by
-the AST walk), never the LCP-stripped display string. The display string is a
-human-readable hint; the link must resolve in the repo.
+Always the **prefix-stripped** form of `entry.file` — the same prefix used to
+produce the display string (longest common path-component prefix, with CWD
+fallback). This is what makes the URL resolve on GitHub: in CI the prefix
+falls back to the repo checkout root, so an absolute
+`/home/runner/work/repo/repo/src/main.rs` becomes the repo-relative
+`src/main.rs` in the URL.
 
-When `entry.file` is absolute, the link will only resolve if the absolute
-path is also a valid repo path, which it normally isn't. Local runs without
-flags don't produce links anyway, and CI runs `cargo crap` from the repo root
-so paths are repo-relative — covered by an integration test.
+If stripping leaves the path still absolute (no LCP, path not under CWD —
+unusual outside of test fixtures or odd local invocations), the row falls
+back to plain code spans without links. A `host/repo/blob/<sha>//abs/...`
+URL would 404, and a broken link is worse than no link.
 
 ### `Format::Json` / `Format::Github` / `Format::Human`
 

--- a/specs/12-pr-comment-source-links.md
+++ b/specs/12-pr-comment-source-links.md
@@ -52,17 +52,20 @@ Then  every rendered Function cell has the form ``[`<name>`](<repo-url>/blob/<re
 And   every rendered Location cell has the form ``[`<displayed-loc>`](<repo-url>/blob/<ref>/<path>#L<line>)``
 ```
 
-### Scenario: Link URL uses the LCP/CWD-stripped path so it resolves on GitHub
+### Scenario: Link URL uses the CWD-relative path (NOT the display LCP)
 
 ```
-Given an entry whose AST-discovered file path is absolute (e.g.
-      `/home/runner/work/repo/repo/src/main.rs`) — typical for
-      `--workspace` runs where cargo metadata returns absolute paths
-And   the run's CWD is the repo root (`/home/runner/work/repo/repo`)
+Given two or more rendered entries whose AST-discovered paths are
+      absolute and live under CWD (e.g. cargo metadata under --workspace
+      returns `/home/runner/work/repo/repo/src/main.rs` etc.)
 And   --repo-url + --commit-ref are set
 When  the pr-comment renders
-Then  the markdown link target uses the path relative to that CWD/LCP
+Then  the markdown link target uses the path stripped only of CWD
       (e.g. `<repo-url>/blob/<ref>/src/main.rs#L<line>`)
+And   the URL keeps any directory segments shared by all rendered rows
+      (the visible Location text may strip them via LCP — that's a
+      readability rule and it must NOT propagate to the URL, or links
+      land at `host/repo/blob/<sha>/main.rs` and 404)
 And   the URL contains exactly one `/blob/` separator (no `//blob/`)
 And   the URL contains no leading `/` between `<ref>/` and the path
 ```
@@ -232,17 +235,26 @@ Apply to both the backtick-wrapped Function name and the backtick-wrapped
 
 ### Path used in the URL
 
-Always the **prefix-stripped** form of `entry.file` — the same prefix used to
-produce the display string (longest common path-component prefix, with CWD
-fallback). This is what makes the URL resolve on GitHub: in CI the prefix
-falls back to the repo checkout root, so an absolute
-`/home/runner/work/repo/repo/src/main.rs` becomes the repo-relative
-`src/main.rs` in the URL.
+The display rule and the URL rule use **different** prefixes — this is the
+whole point.
 
-If stripping leaves the path still absolute (no LCP, path not under CWD —
-unusual outside of test fixtures or odd local invocations), the row falls
-back to plain code spans without links. A `host/repo/blob/<sha>//abs/...`
-URL would 404, and a broken link is worse than no link.
+- **Display** keeps using `compute_render_prefix`: longest common
+  path-component prefix across rendered rows, falling back to CWD when LCP
+  is empty. This shortens the visible Location text to whatever is
+  meaningful in context.
+- **URL** is computed by `link_path`, which strips **only CWD**. If
+  `entry.file` is already relative, it's used verbatim (cargo crap returns
+  repo-relative paths when not invoked with `--workspace`). Otherwise we
+  strip CWD and that's the URL path.
+
+The two MUST stay decoupled. A rendered set that happens to live entirely
+under `src/` will shrink the visible Location to `report.rs:64`, but the
+URL must remain `<repo-url>/blob/<ref>/src/report.rs#L64` — sharing the LCP
+between display and URL would silently ship 404s.
+
+If `link_path` returns `None` (path absolute and not under CWD), the row
+renders as plain code spans without a link. A broken
+`host/repo/blob/<sha>//abs/...` URL is worse than no link at all.
 
 ### `Format::Json` / `Format::Github` / `Format::Human`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
 //! // 4. Render the human-readable table to stdout.
-//! render(&entries, DEFAULT_THRESHOLD, Format::Human, &mut io::stdout())?;
+//! render(&entries, DEFAULT_THRESHOLD, Format::Human, None, &mut io::stdout())?;
 //!
 //! # Ok::<(), anyhow::Error>(())
 //! ```
@@ -133,7 +133,7 @@
 //!
 //! // Exit non-zero if any function regressed.
 //! if report.regression_count() > 0 {
-//!     render_delta(&report, 30.0, Format::Human, &mut io::stdout())?;
+//!     render_delta(&report, 30.0, Format::Human, None, &mut io::stdout())?;
 //!     std::process::exit(1);
 //! }
 //! # Ok::<(), anyhow::Error>(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,10 @@ use cargo_crap::{
     complexity, coverage,
     delta::{compute_delta, load_baseline},
     merge::{MissingCoveragePolicy, merge},
-    report::{Format, crappy_count, render, render_delta, render_delta_summary, render_summary},
+    report::{
+        Format, SourceLinks, crappy_count, render, render_delta, render_delta_summary,
+        render_summary,
+    },
     score::DEFAULT_THRESHOLD,
 };
 use clap::{Parser, ValueEnum};
@@ -123,6 +126,19 @@ struct Cli {
     /// built-in default (0.01).
     #[arg(long, value_name = "VALUE", allow_negative_numbers = true)]
     epsilon: Option<f64>,
+
+    /// Base URL of the source-hosting repo (e.g. `https://github.com/owner/repo`).
+    /// Combined with `--commit-ref`, makes Function and Location cells in
+    /// `pr-comment` / `markdown` output clickable links to GitHub source.
+    /// Defaults from `GITHUB_SERVER_URL` + `GITHUB_REPOSITORY` when those env
+    /// vars are set (e.g. inside GitHub Actions).
+    #[arg(long, value_name = "URL")]
+    repo_url: Option<String>,
+
+    /// Commit SHA or branch name to deep-link into. Defaults from `GITHUB_SHA`
+    /// when set. Has no effect unless `--repo-url` is also set.
+    #[arg(long, value_name = "REF")]
+    commit_ref: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
@@ -396,36 +412,64 @@ fn validate_args(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-/// Render the final report and return `(has_crappy, has_regression)` for exit-code decisions.
-fn do_render(
-    entries: &[cargo_crap::merge::CrapEntry],
-    baseline: Option<&PathBuf>,
+/// Bundles the render-time options threaded into [`do_render`]. Bundling
+/// keeps the helper's signature under clippy's argument-count limit and makes
+/// call sites readable as "what to render" + "where to render it".
+struct RenderOpts<'a> {
     threshold: f64,
     epsilon: f64,
     format: Format,
     summary: bool,
+    links: Option<&'a SourceLinks>,
+}
+
+/// Render the final report and return `(has_crappy, has_regression)` for exit-code decisions.
+fn do_render(
+    entries: &[cargo_crap::merge::CrapEntry],
+    baseline: Option<&PathBuf>,
+    opts: &RenderOpts,
     out: &mut dyn Write,
 ) -> Result<(bool, bool)> {
     if let Some(baseline_path) = baseline {
         let baseline_data = load_baseline(baseline_path)?;
-        let report = compute_delta(entries, &baseline_data, epsilon);
-        let has_crappy = crappy_count(entries, threshold) > 0;
+        let report = compute_delta(entries, &baseline_data, opts.epsilon);
+        let has_crappy = crappy_count(entries, opts.threshold) > 0;
         let has_regression = report.regression_count() > 0;
-        if summary {
+        if opts.summary {
             render_delta_summary(&report, out)?;
         } else {
-            render_delta(&report, threshold, format, out)?;
+            render_delta(&report, opts.threshold, opts.format, opts.links, out)?;
         }
         Ok((has_crappy, has_regression))
     } else {
-        let has_crappy = crappy_count(entries, threshold) > 0;
-        if summary {
-            render_summary(entries, threshold, out)?;
+        let has_crappy = crappy_count(entries, opts.threshold) > 0;
+        if opts.summary {
+            render_summary(entries, opts.threshold, out)?;
         } else {
-            render(entries, threshold, format, out)?;
+            render(entries, opts.threshold, opts.format, opts.links, out)?;
         }
         Ok((has_crappy, false))
     }
+}
+
+/// Resolve `--repo-url` / `--commit-ref` against the GitHub Actions env vars,
+/// returning `Some(SourceLinks)` only when both pieces are present. Either
+/// missing — or both missing — results in `None` (plain rendering, no links).
+fn resolve_source_links(
+    cli_repo_url: Option<String>,
+    cli_commit_ref: Option<String>,
+) -> Option<SourceLinks> {
+    let repo_url = cli_repo_url.or_else(|| {
+        let server = std::env::var("GITHUB_SERVER_URL").ok()?;
+        let repo = std::env::var("GITHUB_REPOSITORY").ok()?;
+        Some(format!(
+            "{}/{}",
+            server.trim_end_matches('/'),
+            repo.trim_start_matches('/')
+        ))
+    })?;
+    let commit_ref = cli_commit_ref.or_else(|| std::env::var("GITHUB_SHA").ok())?;
+    Some(SourceLinks::new(repo_url, commit_ref))
 }
 
 fn main() -> Result<()> {
@@ -488,15 +532,16 @@ fn main() -> Result<()> {
 
     // --- Render ---
     let mut out_box = open_output(cli.output.as_ref())?;
-    let (has_crappy, has_regression) = do_render(
-        &entries,
-        cli.baseline.as_ref(),
+    let links = resolve_source_links(cli.repo_url, cli.commit_ref);
+    let opts = RenderOpts {
         threshold,
         epsilon,
-        cli.format.into(),
-        cli.summary,
-        out_box.as_mut(),
-    )?;
+        format: cli.format.into(),
+        summary: cli.summary,
+        links: links.as_ref(),
+    };
+    let (has_crappy, has_regression) =
+        do_render(&entries, cli.baseline.as_ref(), &opts, out_box.as_mut())?;
 
     if (fail_above && has_crappy) || (fail_regression && has_regression) {
         std::process::exit(1);

--- a/src/report.rs
+++ b/src/report.rs
@@ -14,6 +14,61 @@ use std::path::{Path, PathBuf};
 /// the comment stays under GitHub's 65,536-character body limit on huge PRs.
 const MAX_ROWS_PER_SECTION: usize = 25;
 
+/// Repo URL + commit ref used by `markdown` / `pr-comment` renderers to wrap
+/// Function and Location cells in clickable source links.
+///
+/// Constructed once at the CLI layer (or by library callers) and threaded
+/// through as `Option<&SourceLinks>` — `None` means "no flags set, render
+/// plain code spans like before".
+#[derive(Clone, Debug)]
+pub struct SourceLinks {
+    repo_url: String,
+    commit_ref: String,
+}
+
+impl SourceLinks {
+    /// Trims a trailing `/` off `repo_url` so URL composition produces exactly
+    /// one slash between the base and `/blob/...`.
+    pub fn new(
+        repo_url: String,
+        commit_ref: String,
+    ) -> Self {
+        Self {
+            repo_url: repo_url.trim_end_matches('/').to_string(),
+            commit_ref,
+        }
+    }
+
+    /// Build a deep link to `file` at `line` on the configured ref.
+    pub fn url_for(
+        &self,
+        file: &Path,
+        line: usize,
+    ) -> String {
+        format!(
+            "{}/blob/{}/{}#L{}",
+            self.repo_url,
+            self.commit_ref,
+            file.display(),
+            line,
+        )
+    }
+}
+
+/// Wrap `inner` (already-formatted, e.g. with backticks) in a markdown link
+/// when `links` is `Some`, otherwise return it as-is.
+fn linkify(
+    inner: String,
+    links: Option<&SourceLinks>,
+    file: &Path,
+    line: usize,
+) -> String {
+    match links {
+        Some(l) => format!("[{inner}]({})", l.url_for(file, line)),
+        None => inner,
+    }
+}
+
 /// Three-tier severity used for row icons and colour.
 ///
 /// `Moderate` sits between `threshold / 3` and `threshold` — a visible warning
@@ -107,14 +162,15 @@ pub fn render(
     entries: &[CrapEntry],
     threshold: f64,
     format: Format,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     match format {
         Format::Json => render_json(entries, out),
         Format::Human => render_human(entries, threshold, out),
         Format::GitHub => render_github(entries, threshold, out),
-        Format::Markdown => render_markdown(entries, threshold, out),
-        Format::PrComment => render_pr_comment(entries, threshold, out),
+        Format::Markdown => render_markdown(entries, threshold, links, out),
+        Format::PrComment => render_pr_comment(entries, threshold, links, out),
     }
 }
 
@@ -467,6 +523,7 @@ fn write_markdown_absolute_summary(
 fn write_markdown_entries_table(
     entries: &[CrapEntry],
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
@@ -477,16 +534,27 @@ fn write_markdown_entries_table(
             Some(p) => format!("{p:.1}"),
             None => "—".to_string(),
         };
+        let func = linkify(
+            format!("`{}`", entry.function),
+            links,
+            &entry.file,
+            entry.line,
+        );
+        let loc = linkify(
+            format!("`{}:{}`", entry.file.display(), entry.line),
+            links,
+            &entry.file,
+            entry.line,
+        );
         writeln!(
             out,
-            "| {} | {:.1} | {} | {} | `{}` | `{}:{}` |",
+            "| {} | {:.1} | {} | {} | {} | {} |",
             grade.icon(),
             entry.crap,
             entry.cyclomatic as usize,
             cov,
-            entry.function,
-            entry.file.display(),
-            entry.line,
+            func,
+            loc,
         )?;
     }
     Ok(())
@@ -497,6 +565,7 @@ fn write_markdown_entries_table(
 fn render_markdown(
     entries: &[CrapEntry],
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -507,7 +576,7 @@ fn render_markdown(
     let crappy = crappy_count(entries, threshold);
     write_markdown_absolute_heading(crappy, threshold, out)?;
     write_per_crate_markdown(entries, threshold, out)?;
-    write_markdown_entries_table(entries, threshold, out)?;
+    write_markdown_entries_table(entries, threshold, links, out)?;
     write_markdown_absolute_summary(crappy, entries.len(), threshold, out)
 }
 
@@ -553,6 +622,7 @@ fn write_markdown_delta_heading(
 fn write_delta_entries_table(
     entries: &[crate::delta::DeltaEntry],
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
@@ -561,17 +631,23 @@ fn write_delta_entries_table(
         let e = &de.current;
         let grade = Grade::of(e.crap, threshold);
         let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
+        let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+        let loc = linkify(
+            format!("`{}:{}`", e.file.display(), e.line),
+            links,
+            &e.file,
+            e.line,
+        );
         writeln!(
             out,
-            "| {} | {:.1} | {} | {} | {} | `{}` | `{}:{}` |",
+            "| {} | {:.1} | {} | {} | {} | {} | {} |",
             grade.icon(),
             e.crap,
             delta_display(de),
             e.cyclomatic as usize,
             cov,
-            e.function,
-            e.file.display(),
-            e.line,
+            func,
+            loc,
         )?;
     }
     Ok(())
@@ -613,6 +689,7 @@ fn write_markdown_delta_stats(
 fn render_delta_markdown(
     report: &DeltaReport,
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -621,7 +698,7 @@ fn render_delta_markdown(
         return Ok(());
     }
     write_markdown_delta_heading(report.regression_count(), out)?;
-    write_delta_entries_table(&report.entries, threshold, out)?;
+    write_delta_entries_table(&report.entries, threshold, links, out)?;
     if !report.removed.is_empty() {
         write_markdown_removed(&report.removed, out)?;
     }
@@ -696,22 +773,24 @@ fn write_pr_comment_row(
     de: &DeltaEntry,
     threshold: f64,
     prefix: &Path,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     let e = &de.current;
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
-    let loc = strip_to_display(&e.file, prefix);
+    let loc_text = strip_to_display(&e.file, prefix);
+    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
     writeln!(
         out,
-        "| {} | {:.1} | {} | {} | {} | `{}` | `{}:{}` |",
+        "| {} | {:.1} | {} | {} | {} | {} | {} |",
         grade.icon(),
         e.crap,
         delta_display(de),
         e.cyclomatic as usize,
         cov,
-        e.function,
+        func,
         loc,
-        e.line,
     )?;
     Ok(())
 }
@@ -722,20 +801,22 @@ fn write_pr_comment_abs_row(
     e: &CrapEntry,
     threshold: f64,
     prefix: &Path,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
-    let loc = strip_to_display(&e.file, prefix);
+    let loc_text = strip_to_display(&e.file, prefix);
+    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
     writeln!(
         out,
-        "| {} | {:.1} | {} | {} | `{}` | `{}:{}` |",
+        "| {} | {:.1} | {} | {} | {} | {} |",
         grade.icon(),
         e.crap,
         e.cyclomatic as usize,
         cov,
-        e.function,
+        func,
         loc,
-        e.line,
     )?;
     Ok(())
 }
@@ -878,6 +959,7 @@ fn write_pr_comment_primary(
     b: &DeltaBuckets,
     threshold: f64,
     prefix: &Path,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     let total = b.regressed.len() + b.new_entries.len();
     if total == 0 {
@@ -892,7 +974,7 @@ fn write_pr_comment_primary(
         .chain(b.new_entries.iter())
         .take(MAX_ROWS_PER_SECTION)
     {
-        write_pr_comment_row(out, de, threshold, prefix)?;
+        write_pr_comment_row(out, de, threshold, prefix, links)?;
     }
     write_truncation_if_capped(out, total)
 }
@@ -902,6 +984,7 @@ fn write_pr_comment_improved_section(
     b: &DeltaBuckets,
     threshold: f64,
     prefix: &Path,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     if b.improved.is_empty() {
         return Ok(());
@@ -916,7 +999,7 @@ fn write_pr_comment_improved_section(
     writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
     writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
     for de in b.improved.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_row(out, de, threshold, prefix)?;
+        write_pr_comment_row(out, de, threshold, prefix, links)?;
     }
     write_truncation_if_capped(out, b.improved.len())?;
     writeln!(out)?;
@@ -929,6 +1012,7 @@ fn write_pr_comment_hot_spots_section(
     b: &DeltaBuckets,
     threshold: f64,
     prefix: &Path,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     if b.hot_spots.is_empty() {
         return Ok(());
@@ -942,7 +1026,7 @@ fn write_pr_comment_hot_spots_section(
     writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
     writeln!(out, "|---|---:|---:|---:|---|---|")?;
     for de in b.hot_spots.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_abs_row(out, &de.current, threshold, prefix)?;
+        write_pr_comment_abs_row(out, &de.current, threshold, prefix, links)?;
     }
     write_truncation_if_capped(out, b.hot_spots.len())?;
     writeln!(out)?;
@@ -990,6 +1074,7 @@ fn unchanged_count(report: &DeltaReport) -> usize {
 fn render_delta_pr_comment(
     report: &DeltaReport,
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -1001,9 +1086,9 @@ fn render_delta_pr_comment(
     let prefix = buckets.common_prefix();
     write_pr_comment_delta_headline(out, buckets.regressed.len())?;
     write_pr_comment_breakdown(out, &buckets, unchanged_count(report))?;
-    write_pr_comment_primary(out, &buckets, threshold, &prefix)?;
-    write_pr_comment_improved_section(out, &buckets, threshold, &prefix)?;
-    write_pr_comment_hot_spots_section(out, &buckets, threshold, &prefix)?;
+    write_pr_comment_primary(out, &buckets, threshold, &prefix, links)?;
+    write_pr_comment_improved_section(out, &buckets, threshold, &prefix, links)?;
+    write_pr_comment_hot_spots_section(out, &buckets, threshold, &prefix, links)?;
     write_pr_comment_removed_section(out, &buckets, &prefix)
 }
 
@@ -1037,6 +1122,7 @@ fn write_pr_comment_abs_table(
     out: &mut dyn Write,
     above: &[&CrapEntry],
     threshold: f64,
+    links: Option<&SourceLinks>,
 ) -> Result<()> {
     if above.is_empty() {
         return Ok(());
@@ -1047,7 +1133,7 @@ fn write_pr_comment_abs_table(
     writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
     writeln!(out, "|---|---:|---:|---:|---|---|")?;
     for e in above.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_abs_row(out, e, threshold, &prefix)?;
+        write_pr_comment_abs_row(out, e, threshold, &prefix, links)?;
     }
     write_truncation_if_capped(out, above.len())
 }
@@ -1055,6 +1141,7 @@ fn write_pr_comment_abs_table(
 fn render_pr_comment(
     entries: &[CrapEntry],
     threshold: f64,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -1069,7 +1156,7 @@ fn render_pr_comment(
         entries.len()
     )?;
     let above = above_threshold_sorted(entries, threshold);
-    write_pr_comment_abs_table(out, &above, threshold)
+    write_pr_comment_abs_table(out, &above, threshold, links)
 }
 
 // ─── Summary-only rendering ──────────────────────────────────────────────────
@@ -1167,14 +1254,15 @@ pub fn render_delta(
     report: &DeltaReport,
     threshold: f64,
     format: Format,
+    links: Option<&SourceLinks>,
     out: &mut dyn Write,
 ) -> Result<()> {
     match format {
         Format::Json => render_delta_json(report, out),
         Format::Human => render_delta_human(report, threshold, out),
         Format::GitHub => render_delta_github(report, threshold, out),
-        Format::Markdown => render_delta_markdown(report, threshold, out),
-        Format::PrComment => render_delta_pr_comment(report, threshold, out),
+        Format::Markdown => render_delta_markdown(report, threshold, links, out),
+        Format::PrComment => render_delta_pr_comment(report, threshold, links, out),
     }
 }
 
@@ -1423,7 +1511,7 @@ mod tests {
     #[test]
     fn json_output_is_envelope_with_version_and_entries() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Json, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Json, None, &mut buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert!(parsed.is_object(), "JSON output must be an envelope object");
         assert_eq!(
@@ -1447,7 +1535,7 @@ mod tests {
     #[test]
     fn human_output_mentions_every_function() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("clean"));
         assert!(s.contains("crappy"));
@@ -1466,7 +1554,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::Human, &mut buf).unwrap();
+        render(&all_clean, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains('✓'),
@@ -1486,7 +1574,7 @@ mod tests {
         // Note: ✓ appears in the row icon for the clean function, so we check
         // the summary count rather than the absence of ✓ in the full output.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('✗'), "output must show ✗ for crappy functions");
         assert!(s.contains("1/2"), "summary must report 1 out of 2 crappy");
@@ -1495,7 +1583,7 @@ mod tests {
     #[test]
     fn empty_entries_prints_no_functions_found() {
         let mut buf = Vec::new();
-        render(&[], 30.0, Format::Human, &mut buf).unwrap();
+        render(&[], 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("No functions found."));
     }
@@ -1513,7 +1601,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('—'), "None coverage must render as —");
     }
@@ -1531,7 +1619,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("44.4"), "Some(44.4) must render as 44.4");
     }
@@ -1560,7 +1648,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&both_crappy, 30.0, Format::Human, &mut buf).unwrap();
+        render(&both_crappy, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("2/2"), "both functions crappy, must report 2/2");
     }
@@ -1657,7 +1745,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('▲'), "moderate score must show ▲");
         assert!(!s.contains('✗'), "moderate score must not show ✗");
@@ -1669,7 +1757,7 @@ mod tests {
     fn github_format_emits_warning_for_crappy_function() {
         // Kills: missing the crappy-only guard (`entry.crap > threshold`).
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::GitHub, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("::warning"),
@@ -1686,7 +1774,7 @@ mod tests {
     fn github_format_clean_function_produces_no_annotation() {
         // Kills: emitting annotations for all functions regardless of threshold.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::GitHub, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         // "clean" (crap=1.0) is well below threshold=30 and must be silent.
         assert!(
@@ -1709,7 +1797,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::GitHub, &mut buf).unwrap();
+        render(&all_clean, 30.0, Format::GitHub, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.is_empty(),
@@ -1730,7 +1818,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::GitHub, &mut buf).unwrap();
+        render(&entries, 30.0, Format::GitHub, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("line=42"),
@@ -1842,7 +1930,7 @@ mod tests {
 
     fn render_delta_pr_to_string(report: &DeltaReport) -> String {
         let mut buf = Vec::new();
-        render_delta_pr_comment(report, 30.0, &mut buf).unwrap();
+        render_delta_pr_comment(report, 30.0, None, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -2213,7 +2301,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.starts_with("<!-- cargo-crap-report -->"));
     }
@@ -2230,7 +2318,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("## ✅ No CRAP threshold violations"));
     }
@@ -2292,7 +2380,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
 
         // Only `above` must appear in the table; the headline still shows it.
@@ -2322,7 +2410,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("`very_crappy`"),
@@ -2383,6 +2471,241 @@ mod tests {
         assert!(
             s.contains("· 3 unchanged ·"),
             "breakdown must report 3 unchanged, got:\n{s}"
+        );
+    }
+
+    // --- Source links (spec 12) --------------------------------------------
+
+    fn render_delta_pr_with_links(
+        report: &DeltaReport,
+        links: &SourceLinks,
+    ) -> String {
+        let mut buf = Vec::new();
+        render_delta_pr_comment(report, 30.0, Some(links), &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn source_links_url_for_joins_components_with_one_slash() {
+        let l = SourceLinks::new("https://github.com/owner/repo".into(), "abc123".into());
+        let url = l.url_for(Path::new("src/foo.rs"), 42);
+        assert_eq!(
+            url,
+            "https://github.com/owner/repo/blob/abc123/src/foo.rs#L42"
+        );
+    }
+
+    #[test]
+    fn source_links_strips_trailing_slash_from_repo_url() {
+        let l = SourceLinks::new("https://github.com/owner/repo/".into(), "abc123".into());
+        let url = l.url_for(Path::new("src/foo.rs"), 1);
+        assert!(
+            !url.contains("repo//blob"),
+            "trailing slash must be normalized: {url}"
+        );
+        assert!(url.contains("/repo/blob/abc123/"));
+    }
+
+    #[test]
+    fn pr_comment_no_links_when_links_arg_is_none() {
+        // Default rendering (None) must not contain markdown links — the
+        // table cells stay as plain code spans.
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "src/a.rs",
+                "foo",
+                12.0,
+                Some(5.0),
+                DeltaStatus::Regressed,
+            )],
+            removed: vec![],
+        };
+        let s = render_delta_pr_to_string(&report);
+        assert!(
+            !s.contains("](https://"),
+            "no links expected when links arg is None:\n{s}"
+        );
+        assert!(s.contains("`foo`"), "function name must still render");
+    }
+
+    #[test]
+    fn pr_comment_links_function_and_location_when_set() {
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "src/a.rs",
+                "foo",
+                12.0,
+                Some(5.0),
+                DeltaStatus::Regressed,
+            )],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/owner/repo".into(), "deadbeef".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        let url = "https://github.com/owner/repo/blob/deadbeef/src/a.rs#L1";
+        // Function cell wrapped in a link.
+        assert!(
+            s.contains(&format!("[`foo`]({url})")),
+            "function cell must be a markdown link, got:\n{s}"
+        );
+        // Location cell wrapped in a link too. The visible text uses the
+        // LCP-stripped form (single entry → CWD fallback or absolute), but
+        // the URL must always use the original path.
+        let loc_link_target = format!("]({url})");
+        let count = s.matches(&loc_link_target).count();
+        assert!(
+            count >= 2,
+            "both Function and Location must link to the same URL, got count={count}:\n{s}"
+        );
+    }
+
+    #[test]
+    fn pr_comment_link_url_uses_original_path_not_stripped() {
+        // Single-entry path → LCP is empty and the path is left absolute
+        // (outside-CWD case). The link URL must still use the *original*
+        // entry.file, regardless of what the visible Location text shows.
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "/abs/repo/src/schema.rs",
+                "compile_schema",
+                12.0,
+                Some(5.0),
+                DeltaStatus::Regressed,
+            )],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/o/r".into(), "sha1".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(
+            s.contains("https://github.com/o/r/blob/sha1//abs/repo/src/schema.rs#L1"),
+            "link target must be derived from the full original path:\n{s}"
+        );
+    }
+
+    #[test]
+    fn pr_comment_removed_entries_are_not_linked() {
+        // Removed functions don't exist on HEAD — linking them would 404.
+        let report = DeltaReport {
+            entries: vec![],
+            removed: vec![RemovedEntry {
+                function: "gone_fn".into(),
+                file: PathBuf::from("src/a.rs"),
+                baseline_crap: 8.0,
+            }],
+        };
+        let links = SourceLinks::new("https://github.com/owner/repo".into(), "sha".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(s.contains("gone_fn"));
+        assert!(
+            !s.contains("](https://"),
+            "removed entries must not be wrapped in links:\n{s}"
+        );
+    }
+
+    #[test]
+    fn pr_comment_hot_spots_get_links() {
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "src/a.rs",
+                "hot_fn",
+                80.0,
+                Some(80.0),
+                DeltaStatus::Unchanged,
+            )],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/owner/repo".into(), "sha".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(
+            s.contains("[`hot_fn`](https://github.com/owner/repo/blob/sha/src/a.rs#L1)"),
+            "hot-spot Function cell must be a link:\n{s}"
+        );
+    }
+
+    #[test]
+    fn pr_comment_improved_get_links() {
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "src/a.rs",
+                "improved_fn",
+                3.0,
+                Some(10.0),
+                DeltaStatus::Improved,
+            )],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/owner/repo".into(), "sha".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(
+            s.contains("[`improved_fn`](https://github.com/owner/repo/blob/sha/src/a.rs#L1)"),
+            "improved Function cell must be a link:\n{s}"
+        );
+    }
+
+    #[test]
+    fn pr_comment_absolute_table_gets_links() {
+        let entries = vec![CrapEntry {
+            file: PathBuf::from("src/a.rs"),
+            function: "very_crappy".into(),
+            line: 42,
+            cyclomatic: 10.0,
+            coverage: Some(0.0),
+            crap: 110.0,
+            crate_name: None,
+        }];
+        let links = SourceLinks::new("https://github.com/o/r".into(), "abc".into());
+        let mut buf = Vec::new();
+        render(&entries, 30.0, Format::PrComment, Some(&links), &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("[`very_crappy`](https://github.com/o/r/blob/abc/src/a.rs#L42)"),
+            "absolute pr-comment must link Function:\n{s}"
+        );
+    }
+
+    #[test]
+    fn markdown_format_also_emits_links() {
+        let entries = vec![CrapEntry {
+            file: PathBuf::from("src/a.rs"),
+            function: "foo".into(),
+            line: 7,
+            cyclomatic: 1.0,
+            coverage: Some(50.0),
+            crap: 5.0,
+            crate_name: None,
+        }];
+        let links = SourceLinks::new("https://github.com/o/r".into(), "main".into());
+        let mut buf = Vec::new();
+        render(&entries, 30.0, Format::Markdown, Some(&links), &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("[`foo`](https://github.com/o/r/blob/main/src/a.rs#L7)"),
+            "markdown format must link Function:\n{s}"
+        );
+        assert!(
+            s.contains("[`src/a.rs:7`](https://github.com/o/r/blob/main/src/a.rs#L7)"),
+            "markdown format must link Location:\n{s}"
+        );
+    }
+
+    #[test]
+    fn json_format_unaffected_by_links() {
+        let entries = vec![CrapEntry {
+            file: PathBuf::from("src/a.rs"),
+            function: "foo".into(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap: 1.0,
+            crate_name: None,
+        }];
+        let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let mut buf = Vec::new();
+        render(&entries, 30.0, Format::Json, Some(&links), &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            !s.contains("](https://"),
+            "JSON output must not contain markdown links:\n{s}"
         );
     }
 
@@ -2482,7 +2805,7 @@ mod tests {
     fn render_human_includes_per_crate_section_when_workspace() {
         let entries = vec![entry(Some("alpha"), "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("Per-crate summary:"),
@@ -2495,7 +2818,7 @@ mod tests {
     fn render_human_omits_per_crate_section_when_no_workspace_data() {
         let entries = vec![entry(None, "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             !s.contains("Per-crate summary"),

--- a/src/report.rs
+++ b/src/report.rs
@@ -55,25 +55,24 @@ impl SourceLinks {
     }
 }
 
-/// Decide what to embed into a `/blob/<ref>/...` URL for `path`.
+/// Decide what path to embed into a `/blob/<ref>/...` URL for `path`.
 ///
-/// Returns the prefix-stripped, repo-relative form when stripping succeeds
-/// and produces a relative path. Returns `None` when the result would still
-/// be absolute (no LCP, path outside CWD) — those rows render without links
-/// because a `host/repo/blob/<sha>//abs/...` URL would 404.
-fn link_path(
-    path: &Path,
-    prefix: &Path,
-) -> Option<PathBuf> {
-    if !prefix.as_os_str().is_empty()
-        && let Ok(rel) = path.strip_prefix(prefix)
-    {
-        return Some(rel.to_path_buf());
-    }
+/// The URL prefix is **always the repo root (== CWD)**, never the LCP used
+/// for the visible Location text. If we shared the LCP, a rendered set that
+/// happens to live entirely under `src/` would strip `src/` from the URL
+/// too, yielding `host/repo/blob/<sha>/main.rs` which 404s.
+///
+/// Returns the repo-relative form when `path` is already relative (cargo
+/// crap reports relative paths when not invoked with `--workspace`) or
+/// absolute under CWD. Returns `None` otherwise — those rows fall back to
+/// plain code spans rather than emit a broken
+/// `host/repo/blob/<sha>//abs/...` URL.
+fn link_path(path: &Path) -> Option<PathBuf> {
     if path.is_relative() {
         return Some(path.to_path_buf());
     }
-    None
+    let cwd = std::env::current_dir().ok()?;
+    path.strip_prefix(&cwd).ok().map(|p| p.to_path_buf())
 }
 
 /// Wrap `inner` (already-formatted, e.g. with backticks) in a markdown link
@@ -83,10 +82,9 @@ fn linkify(
     inner: String,
     links: Option<&SourceLinks>,
     file: &Path,
-    prefix: &Path,
     line: usize,
 ) -> String {
-    match (links, link_path(file, prefix)) {
+    match (links, link_path(file)) {
         (Some(l), Some(p)) => format!("[{inner}]({})", l.url_for(&p, line)),
         _ => inner,
     }
@@ -547,7 +545,6 @@ fn write_markdown_entries_table(
     entries: &[CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
-    prefix: &Path,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
@@ -562,14 +559,12 @@ fn write_markdown_entries_table(
             format!("`{}`", entry.function),
             links,
             &entry.file,
-            prefix,
             entry.line,
         );
         let loc = linkify(
             format!("`{}:{}`", entry.file.display(), entry.line),
             links,
             &entry.file,
-            prefix,
             entry.line,
         );
         writeln!(
@@ -602,9 +597,7 @@ fn render_markdown(
     let crappy = crappy_count(entries, threshold);
     write_markdown_absolute_heading(crappy, threshold, out)?;
     write_per_crate_markdown(entries, threshold, out)?;
-    let paths: Vec<PathBuf> = entries.iter().map(|e| e.file.clone()).collect();
-    let prefix = compute_render_prefix(&paths);
-    write_markdown_entries_table(entries, threshold, links, &prefix, out)?;
+    write_markdown_entries_table(entries, threshold, links, out)?;
     write_markdown_absolute_summary(crappy, entries.len(), threshold, out)
 }
 
@@ -651,7 +644,6 @@ fn write_delta_entries_table(
     entries: &[crate::delta::DeltaEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
-    prefix: &Path,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
@@ -660,12 +652,11 @@ fn write_delta_entries_table(
         let e = &de.current;
         let grade = Grade::of(e.crap, threshold);
         let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
-        let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
+        let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
         let loc = linkify(
             format!("`{}:{}`", e.file.display(), e.line),
             links,
             &e.file,
-            prefix,
             e.line,
         );
         writeln!(
@@ -728,13 +719,7 @@ fn render_delta_markdown(
         return Ok(());
     }
     write_markdown_delta_heading(report.regression_count(), out)?;
-    let paths: Vec<PathBuf> = report
-        .entries
-        .iter()
-        .map(|e| e.current.file.clone())
-        .collect();
-    let prefix = compute_render_prefix(&paths);
-    write_delta_entries_table(&report.entries, threshold, links, &prefix, out)?;
+    write_delta_entries_table(&report.entries, threshold, links, out)?;
     if !report.removed.is_empty() {
         write_markdown_removed(&report.removed, out)?;
     }
@@ -815,14 +800,8 @@ fn write_pr_comment_row(
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
-    let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
-    let loc = linkify(
-        format!("`{loc_text}:{}`", e.line),
-        links,
-        &e.file,
-        prefix,
-        e.line,
-    );
+    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
     writeln!(
         out,
         "| {} | {:.1} | {} | {} | {} | {} | {} |",
@@ -848,14 +827,8 @@ fn write_pr_comment_abs_row(
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
-    let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
-    let loc = linkify(
-        format!("`{loc_text}:{}`", e.line),
-        links,
-        &e.file,
-        prefix,
-        e.line,
-    );
+    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
     writeln!(
         out,
         "| {} | {:.1} | {} | {} | {} | {} |",
@@ -2639,12 +2612,69 @@ mod tests {
     }
 
     #[test]
+    fn pr_comment_link_url_does_not_strip_lcp_when_lcp_is_below_repo_root() {
+        // Regression test for the original CI bug: when every rendered
+        // entry lives under `src/`, the LCP (used for visible Location
+        // text) is `<cwd>/src`. The URL must NOT inherit that — it has to
+        // strip CWD only, otherwise `host/repo/blob/<sha>/main.rs` 404s
+        // (the repo path is `src/main.rs`).
+        let cwd = std::env::current_dir().expect("cwd");
+        let a = cwd.join("src").join("a.rs");
+        let b = cwd.join("src").join("b.rs");
+        let report = DeltaReport {
+            entries: vec![
+                delta_entry(
+                    a.to_str().unwrap(),
+                    "fn_a",
+                    12.0,
+                    Some(5.0),
+                    DeltaStatus::Regressed,
+                ),
+                delta_entry(
+                    b.to_str().unwrap(),
+                    "fn_b",
+                    14.0,
+                    Some(5.0),
+                    DeltaStatus::Regressed,
+                ),
+            ],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(
+            s.contains("/blob/sha/src/a.rs#L1"),
+            "URL must keep the src/ segment (CWD-relative, not LCP-relative):\n{s}"
+        );
+        assert!(
+            !s.contains("/blob/sha/a.rs#L1"),
+            "URL must not strip src/ even when it's the LCP across rendered rows:\n{s}"
+        );
+    }
+
+    #[test]
     fn pr_comment_skips_link_when_path_cannot_be_made_repo_relative() {
-        // Path NOT under CWD and no LCP with anything else → link_path
-        // returns None and the row falls back to plain code spans.
+        // Path NOT under CWD → link_path returns None and the row falls
+        // back to plain code spans. Use `std::env::temp_dir()` because a
+        // Unix-style `/totally/elsewhere/foo.rs` is treated as RELATIVE on
+        // Windows (no drive letter), which would defeat the test;
+        // `temp_dir()` is absolute on every platform and reliably outside
+        // the cargo-project CWD.
+        let outside = std::env::temp_dir()
+            .join("cargo_crap_link_test")
+            .join("foo.rs");
+        assert!(
+            outside.is_absolute(),
+            "test setup: temp path must be absolute"
+        );
+        let cwd = std::env::current_dir().expect("cwd");
+        assert!(
+            !outside.starts_with(&cwd),
+            "test setup: temp path must not be under CWD"
+        );
         let report = DeltaReport {
             entries: vec![delta_entry(
-                "/totally/elsewhere/foo.rs",
+                outside.to_str().expect("utf8"),
                 "stranger",
                 12.0,
                 Some(5.0),

--- a/src/report.rs
+++ b/src/report.rs
@@ -2617,13 +2617,13 @@ mod tests {
         };
         let links = SourceLinks::new("https://github.com/o/r".into(), "sha1".into());
         let s = render_delta_pr_with_links(&report, &links);
-        // PathBuf::display uses platform separators, so build the expected
-        // tail the same way and assert containment instead of full equality.
-        let rel = std::path::Path::new("src").join("schema.rs");
-        let expected = format!("https://github.com/o/r/blob/sha1/{}#L1", rel.display());
+        // GitHub URLs always use forward slashes — `url_for` normalizes
+        // backslashes — so the expected literal is the same on every OS.
+        let expected = "https://github.com/o/r/blob/sha1/src/schema.rs#L1";
         assert!(
-            s.contains(&expected),
-            "URL must use CWD-stripped path (expected {expected:?}):\n{s}"
+            s.contains(expected),
+            "URL must use CWD-stripped path with forward slashes \
+             (expected {expected:?}):\n{s}"
         );
         assert!(!s.contains("/blob/sha1//"), "no double slash in URL:\n{s}");
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -40,17 +40,20 @@ impl SourceLinks {
     }
 
     /// Build a deep link to `file` at `line` on the configured ref.
+    ///
+    /// GitHub URLs require forward slashes regardless of host OS. On
+    /// Windows `Path::display()` emits `src\foo.rs`, which would land in
+    /// the URL verbatim and 404 on github.com — so we normalize backslashes
+    /// to forward slashes before composing the URL.
     pub fn url_for(
         &self,
         file: &Path,
         line: usize,
     ) -> String {
+        let path = file.to_string_lossy().replace('\\', "/");
         format!(
             "{}/blob/{}/{}#L{}",
-            self.repo_url,
-            self.commit_ref,
-            file.display(),
-            line,
+            self.repo_url, self.commit_ref, path, line
         )
     }
 }
@@ -2525,6 +2528,20 @@ mod tests {
             "trailing slash must be normalized: {url}"
         );
         assert!(url.contains("/repo/blob/abc123/"));
+    }
+
+    #[test]
+    fn source_links_url_uses_forward_slashes_even_for_windows_input() {
+        // GitHub URLs always use `/`. A Windows-style backslash path must
+        // be normalized before it lands in the URL, otherwise links break
+        // on github.com regardless of which OS rendered them.
+        let l = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let url = l.url_for(Path::new(r"src\foo.rs"), 1);
+        assert!(
+            !url.contains('\\'),
+            "URL must contain no backslashes, got: {url}"
+        );
+        assert_eq!(url, "https://github.com/o/r/blob/sha/src/foo.rs#L1");
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -55,17 +55,40 @@ impl SourceLinks {
     }
 }
 
+/// Decide what to embed into a `/blob/<ref>/...` URL for `path`.
+///
+/// Returns the prefix-stripped, repo-relative form when stripping succeeds
+/// and produces a relative path. Returns `None` when the result would still
+/// be absolute (no LCP, path outside CWD) — those rows render without links
+/// because a `host/repo/blob/<sha>//abs/...` URL would 404.
+fn link_path(
+    path: &Path,
+    prefix: &Path,
+) -> Option<PathBuf> {
+    if !prefix.as_os_str().is_empty()
+        && let Ok(rel) = path.strip_prefix(prefix)
+    {
+        return Some(rel.to_path_buf());
+    }
+    if path.is_relative() {
+        return Some(path.to_path_buf());
+    }
+    None
+}
+
 /// Wrap `inner` (already-formatted, e.g. with backticks) in a markdown link
-/// when `links` is `Some`, otherwise return it as-is.
+/// iff both `links` and a usable (repo-relative) URL path are available;
+/// otherwise return `inner` unchanged.
 fn linkify(
     inner: String,
     links: Option<&SourceLinks>,
     file: &Path,
+    prefix: &Path,
     line: usize,
 ) -> String {
-    match links {
-        Some(l) => format!("[{inner}]({})", l.url_for(file, line)),
-        None => inner,
+    match (links, link_path(file, prefix)) {
+        (Some(l), Some(p)) => format!("[{inner}]({})", l.url_for(&p, line)),
+        _ => inner,
     }
 }
 
@@ -524,6 +547,7 @@ fn write_markdown_entries_table(
     entries: &[CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    prefix: &Path,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
@@ -538,12 +562,14 @@ fn write_markdown_entries_table(
             format!("`{}`", entry.function),
             links,
             &entry.file,
+            prefix,
             entry.line,
         );
         let loc = linkify(
             format!("`{}:{}`", entry.file.display(), entry.line),
             links,
             &entry.file,
+            prefix,
             entry.line,
         );
         writeln!(
@@ -576,7 +602,9 @@ fn render_markdown(
     let crappy = crappy_count(entries, threshold);
     write_markdown_absolute_heading(crappy, threshold, out)?;
     write_per_crate_markdown(entries, threshold, out)?;
-    write_markdown_entries_table(entries, threshold, links, out)?;
+    let paths: Vec<PathBuf> = entries.iter().map(|e| e.file.clone()).collect();
+    let prefix = compute_render_prefix(&paths);
+    write_markdown_entries_table(entries, threshold, links, &prefix, out)?;
     write_markdown_absolute_summary(crappy, entries.len(), threshold, out)
 }
 
@@ -623,6 +651,7 @@ fn write_delta_entries_table(
     entries: &[crate::delta::DeltaEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    prefix: &Path,
     out: &mut dyn Write,
 ) -> Result<()> {
     writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
@@ -631,11 +660,12 @@ fn write_delta_entries_table(
         let e = &de.current;
         let grade = Grade::of(e.crap, threshold);
         let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
-        let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
+        let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
         let loc = linkify(
             format!("`{}:{}`", e.file.display(), e.line),
             links,
             &e.file,
+            prefix,
             e.line,
         );
         writeln!(
@@ -698,7 +728,13 @@ fn render_delta_markdown(
         return Ok(());
     }
     write_markdown_delta_heading(report.regression_count(), out)?;
-    write_delta_entries_table(&report.entries, threshold, links, out)?;
+    let paths: Vec<PathBuf> = report
+        .entries
+        .iter()
+        .map(|e| e.current.file.clone())
+        .collect();
+    let prefix = compute_render_prefix(&paths);
+    write_delta_entries_table(&report.entries, threshold, links, &prefix, out)?;
     if !report.removed.is_empty() {
         write_markdown_removed(&report.removed, out)?;
     }
@@ -779,8 +815,14 @@ fn write_pr_comment_row(
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
-    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
+    let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
+    let loc = linkify(
+        format!("`{loc_text}:{}`", e.line),
+        links,
+        &e.file,
+        prefix,
+        e.line,
+    );
     writeln!(
         out,
         "| {} | {:.1} | {} | {} | {} | {} | {} |",
@@ -806,8 +848,14 @@ fn write_pr_comment_abs_row(
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
-    let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
+    let func = linkify(format!("`{}`", e.function), links, &e.file, prefix, e.line);
+    let loc = linkify(
+        format!("`{loc_text}:{}`", e.line),
+        links,
+        &e.file,
+        prefix,
+        e.line,
+    );
     writeln!(
         out,
         "| {} | {:.1} | {} | {} | {} | {} |",
@@ -2560,13 +2608,16 @@ mod tests {
     }
 
     #[test]
-    fn pr_comment_link_url_uses_original_path_not_stripped() {
-        // Single-entry path → LCP is empty and the path is left absolute
-        // (outside-CWD case). The link URL must still use the *original*
-        // entry.file, regardless of what the visible Location text shows.
+    fn pr_comment_link_url_uses_path_relative_to_cwd() {
+        // Simulate a CI run: cargo metadata produces an absolute path under
+        // the checkout root (== CWD). The display rule strips CWD; the link
+        // URL must use the *same* repo-relative form so it resolves on
+        // GitHub. A `/blob/<sha>//abs/...` URL would 404.
+        let cwd = std::env::current_dir().expect("cwd");
+        let abs = cwd.join("src").join("schema.rs");
         let report = DeltaReport {
             entries: vec![delta_entry(
-                "/abs/repo/src/schema.rs",
+                abs.to_str().expect("utf8"),
                 "compile_schema",
                 12.0,
                 Some(5.0),
@@ -2576,9 +2627,37 @@ mod tests {
         };
         let links = SourceLinks::new("https://github.com/o/r".into(), "sha1".into());
         let s = render_delta_pr_with_links(&report, &links);
+        // PathBuf::display uses platform separators, so build the expected
+        // tail the same way and assert containment instead of full equality.
+        let rel = std::path::Path::new("src").join("schema.rs");
+        let expected = format!("https://github.com/o/r/blob/sha1/{}#L1", rel.display());
         assert!(
-            s.contains("https://github.com/o/r/blob/sha1//abs/repo/src/schema.rs#L1"),
-            "link target must be derived from the full original path:\n{s}"
+            s.contains(&expected),
+            "URL must use CWD-stripped path (expected {expected:?}):\n{s}"
+        );
+        assert!(!s.contains("/blob/sha1//"), "no double slash in URL:\n{s}");
+    }
+
+    #[test]
+    fn pr_comment_skips_link_when_path_cannot_be_made_repo_relative() {
+        // Path NOT under CWD and no LCP with anything else → link_path
+        // returns None and the row falls back to plain code spans.
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "/totally/elsewhere/foo.rs",
+                "stranger",
+                12.0,
+                Some(5.0),
+                DeltaStatus::Regressed,
+            )],
+            removed: vec![],
+        };
+        let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let s = render_delta_pr_with_links(&report, &links);
+        assert!(s.contains("`stranger`"), "function name must still render");
+        assert!(
+            !s.contains("](https://"),
+            "no link expected when path can't be made repo-relative:\n{s}"
         );
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1761,6 +1761,122 @@ fn pr_comment_format_regression_shows_warning_heading() {
         .stdout(predicate::str::contains("crappy"));
 }
 
+// --- --repo-url / --commit-ref (spec 12) ---------------------------------
+
+/// Pin the link rendering for `--format pr-comment`: when both flags are
+/// passed, every Function and Location cell becomes a markdown link to the
+/// repo at that commit.
+#[test]
+fn pr_comment_with_repo_and_ref_emits_links() {
+    let stdout = cmd()
+        .env_remove("GITHUB_SERVER_URL")
+        .env_remove("GITHUB_REPOSITORY")
+        .env_remove("GITHUB_SHA")
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("pr-comment")
+        .arg("--threshold")
+        .arg("0") // force every fixture function above threshold so the table renders
+        .arg("--repo-url")
+        .arg("https://github.com/owner/repo")
+        .arg("--commit-ref")
+        .arg("deadbeef")
+        .output()
+        .expect("run")
+        .stdout;
+    let stdout = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        stdout.contains("](https://github.com/owner/repo/blob/deadbeef/"),
+        "expected at least one link to GitHub source, got:\n{stdout}"
+    );
+}
+
+/// Without either flag and with no GITHUB_* env vars, the renderer must
+/// fall back to the plain code-span output (no markdown links).
+#[test]
+fn pr_comment_without_repo_or_env_emits_no_links() {
+    let stdout = cmd()
+        .env_remove("GITHUB_SERVER_URL")
+        .env_remove("GITHUB_REPOSITORY")
+        .env_remove("GITHUB_SHA")
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("pr-comment")
+        .arg("--threshold")
+        .arg("0")
+        .output()
+        .expect("run")
+        .stdout;
+    let stdout = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        !stdout.contains("](https://"),
+        "no markdown links expected without flags or env vars:\n{stdout}"
+    );
+}
+
+/// GitHub Actions env vars (GITHUB_SERVER_URL + GITHUB_REPOSITORY + GITHUB_SHA)
+/// must produce links when no CLI flags are passed.
+#[test]
+fn pr_comment_picks_up_github_env_vars() {
+    let stdout = cmd()
+        .env("GITHUB_SERVER_URL", "https://example.com")
+        .env("GITHUB_REPOSITORY", "acme/widget")
+        .env("GITHUB_SHA", "feedface")
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("pr-comment")
+        .arg("--threshold")
+        .arg("0")
+        .output()
+        .expect("run")
+        .stdout;
+    let stdout = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        stdout.contains("](https://example.com/acme/widget/blob/feedface/"),
+        "env-var defaults must drive link generation:\n{stdout}"
+    );
+}
+
+/// CLI flags override env vars when both are present.
+#[test]
+fn cli_flags_override_github_env_vars() {
+    let stdout = cmd()
+        .env("GITHUB_SERVER_URL", "https://example.com")
+        .env("GITHUB_REPOSITORY", "acme/widget")
+        .env("GITHUB_SHA", "env_sha")
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("pr-comment")
+        .arg("--threshold")
+        .arg("0")
+        .arg("--commit-ref")
+        .arg("cli_sha")
+        .output()
+        .expect("run")
+        .stdout;
+    let stdout = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        stdout.contains("/blob/cli_sha/"),
+        "CLI --commit-ref must override GITHUB_SHA:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("/blob/env_sha/"),
+        "env GITHUB_SHA must not appear when overridden:\n{stdout}"
+    );
+}
+
 // --- --jobs ---------------------------------------------------------------
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -98,8 +98,14 @@ fn json_output_round_trips() {
     let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic).entries;
 
     let mut buf = Vec::new();
-    cargo_crap::report::render(&entries, 30.0, cargo_crap::report::Format::Json, &mut buf)
-        .expect("render");
+    cargo_crap::report::render(
+        &entries,
+        30.0,
+        cargo_crap::report::Format::Json,
+        None,
+        &mut buf,
+    )
+    .expect("render");
 
     // If this parses, the output is well-formed.
     let parsed: serde_json::Value =


### PR DESCRIPTION
Adds --repo-url / --commit-ref flags (with GITHUB_SERVER_URL + GITHUB_REPOSITORY + GITHUB_SHA fallbacks) that wrap Function and Location cells in pr-comment / markdown output as markdown links to the file at the given commit. Removed entries stay unlinked since they no longer exist on HEAD. Other formats (json/human/github) are untouched.

The CI workflow passes the PR head SHA so links resolve to the actual commit users browse, not the synthetic merge ref.