### PR TITLE
chore: address Qodana findings (unused dep + path prefixes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ proc-macro2 = { version = "1", features = ["span-locations"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 syn = { version = "2", features = ["full", "visit"] }
-thiserror = "2"
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@
 use crate::merge::MissingCoveragePolicy;
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use std::fs;
 use std::path::Path;
 
 /// Persistent settings loaded from `.cargo-crap.toml`.
@@ -80,7 +81,7 @@ pub fn load(start: &Path) -> Result<Config> {
     loop {
         let candidate = dir.join(".cargo-crap.toml");
         if candidate.exists() {
-            let raw = std::fs::read_to_string(&candidate)
+            let raw = fs::read_to_string(&candidate)
                 .with_context(|| format!("reading {}", candidate.display()))?;
             let cfg: Config =
                 toml::from_str(&raw).with_context(|| format!("parsing {}", candidate.display()))?;
@@ -99,10 +100,10 @@ mod tests {
     use std::io::Write;
 
     fn write_config(
-        dir: &std::path::Path,
+        dir: &Path,
         content: &str,
     ) {
-        let mut f = std::fs::File::create(dir.join(".cargo-crap.toml")).unwrap();
+        let mut f = fs::File::create(dir.join(".cargo-crap.toml")).unwrap();
         f.write_all(content.as_bytes()).unwrap();
     }
 
@@ -143,7 +144,7 @@ allow = ["Foo::*"]
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), "threshold = 15.0\n");
         let subdir = dir.path().join("src");
-        std::fs::create_dir(&subdir).unwrap();
+        fs::create_dir(&subdir).unwrap();
         // Start from a subdirectory — should walk up and find the config.
         let cfg = load(&subdir).unwrap();
         assert_eq!(cfg.threshold, Some(15.0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@
 
 use anyhow::{Context, Result, bail};
 use cargo_crap::{
-    complexity, coverage,
+    complexity,
+    coverage::{self, FileCoverage},
     delta::{compute_delta, load_baseline},
     merge::{MissingCoveragePolicy, merge},
     report::{
@@ -20,6 +21,7 @@ use cargo_crap::{
 use clap::{Parser, ValueEnum};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use indicatif::{ProgressBar, ProgressStyle};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
@@ -299,9 +301,7 @@ fn apply_filters(
 }
 
 /// Parse the LCOV file if one was provided, returning an empty map otherwise.
-fn load_coverage(
-    lcov: Option<&PathBuf>
-) -> Result<std::collections::HashMap<std::path::PathBuf, cargo_crap::coverage::FileCoverage>> {
+fn load_coverage(lcov: Option<&PathBuf>) -> Result<HashMap<PathBuf, FileCoverage>> {
     match lcov {
         Some(path) => coverage::parse_lcov(path)
             .with_context(|| format!("parsing LCOV file {}", path.display())),


### PR DESCRIPTION
- Drop `thiserror` from dependencies — zero references in `src/`.
- Simplify the awkwardly-qualified return type of `load_coverage` in src/main.rs (was `std::collections::HashMap<std::path::PathBuf, cargo_crap::coverage::FileCoverage>`); add the missing imports.
- Drop redundant `std::fs::*` and `std::path::Path` prefixes in src/config.rs by importing the module once at the top.

`proc-macro2` is intentionally kept despite the same Qodana flag — it exists to enable the `span-locations` feature on the transitive dep that powers `Span::start()`/`end()` in src/complexity.rs.