### PR TITLE
feat(delta): move-aware detection (spec 13)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DBNavigator.Project.DDLFileAttachmentManager">
+    <mappings />
+    <preferences />
+  </component>
+  <component name="DBNavigator.Project.DatabaseAssistantManager">
+    <assistants />
+    <selection-state>
+      <model-selection />
+    </selection-state>
+  </component>
+  <component name="DBNavigator.Project.DatabaseFileManager">
+    <open-files />
+  </component>
+  <component name="DBNavigator.Project.Settings">
+    <connections />
+    <browser-settings>
+      <general>
+        <display-mode value="TABBED" />
+        <navigation-history-size value="100" />
+        <show-object-details value="false" />
+        <enable-sticky-paths value="true" />
+        <enable-quick-filters value="false" />
+      </general>
+      <filters>
+        <object-type-filter>
+          <object-type name="SCHEMA" enabled="true" />
+          <object-type name="USER" enabled="true" />
+          <object-type name="ROLE" enabled="true" />
+          <object-type name="PRIVILEGE" enabled="true" />
+          <object-type name="CHARSET" enabled="true" />
+          <object-type name="TABLE" enabled="true" />
+          <object-type name="VIEW" enabled="true" />
+          <object-type name="JSON_VIEW" enabled="true" />
+          <object-type name="MATERIALIZED_VIEW" enabled="true" />
+          <object-type name="NESTED_TABLE" enabled="true" />
+          <object-type name="COLUMN" enabled="true" />
+          <object-type name="INDEX" enabled="true" />
+          <object-type name="CONSTRAINT" enabled="true" />
+          <object-type name="DATASET_TRIGGER" enabled="true" />
+          <object-type name="DATABASE_TRIGGER" enabled="true" />
+          <object-type name="SYNONYM" enabled="true" />
+          <object-type name="SEQUENCE" enabled="true" />
+          <object-type name="PROCEDURE" enabled="true" />
+          <object-type name="FUNCTION" enabled="true" />
+          <object-type name="PACKAGE" enabled="true" />
+          <object-type name="TYPE" enabled="true" />
+          <object-type name="TYPE_ATTRIBUTE" enabled="true" />
+          <object-type name="ARGUMENT" enabled="true" />
+          <object-type name="JAVA_CLASS" enabled="true" />
+          <object-type name="JAVA_FIELD" enabled="true" />
+          <object-type name="JAVA_METHOD" enabled="true" />
+          <object-type name="JAVA_RESOURCE" enabled="true" />
+          <object-type name="DIMENSION" enabled="true" />
+          <object-type name="CLUSTER" enabled="true" />
+          <object-type name="DBLINK" enabled="true" />
+          <object-type name="CREDENTIAL" enabled="true" />
+          <object-type name="AI_PROFILE" enabled="true" />
+          <object-type name="AI_MODEL" enabled="true" />
+        </object-type-filter>
+      </filters>
+      <sorting>
+        <object-type name="COLUMN" sorting-type="NAME" />
+        <object-type name="FUNCTION" sorting-type="NAME" />
+        <object-type name="PROCEDURE" sorting-type="NAME" />
+        <object-type name="ARGUMENT" sorting-type="POSITION" />
+        <object-type name="TYPE ATTRIBUTE" sorting-type="POSITION" />
+      </sorting>
+      <default-editors>
+        <object-type name="VIEW" editor-type="SELECTION" />
+        <object-type name="PACKAGE" editor-type="SELECTION" />
+        <object-type name="TYPE" editor-type="SELECTION" />
+      </default-editors>
+    </browser-settings>
+    <navigation-settings>
+      <lookup-filters>
+        <lookup-objects>
+          <object-type name="SCHEMA" enabled="true" />
+          <object-type name="USER" enabled="false" />
+          <object-type name="ROLE" enabled="false" />
+          <object-type name="PRIVILEGE" enabled="false" />
+          <object-type name="CHARSET" enabled="false" />
+          <object-type name="TABLE" enabled="true" />
+          <object-type name="VIEW" enabled="true" />
+          <object-type name="JSON VIEW" enabled="true" />
+          <object-type name="MATERIALIZED VIEW" enabled="true" />
+          <object-type name="INDEX" enabled="true" />
+          <object-type name="CONSTRAINT" enabled="true" />
+          <object-type name="DATASET TRIGGER" enabled="true" />
+          <object-type name="DATABASE TRIGGER" enabled="true" />
+          <object-type name="SYNONYM" enabled="false" />
+          <object-type name="SEQUENCE" enabled="true" />
+          <object-type name="PROCEDURE" enabled="true" />
+          <object-type name="FUNCTION" enabled="true" />
+          <object-type name="PACKAGE" enabled="true" />
+          <object-type name="TYPE" enabled="true" />
+          <object-type name="JAVA CLASS" enabled="true" />
+          <object-type name="INNER CLASS" enabled="true" />
+          <object-type name="JAVA FIELD" enabled="true" />
+          <object-type name="JAVA METHOD" enabled="true" />
+          <object-type name="JAVA PARAMETER" enabled="true" />
+          <object-type name="JAVA RESOURCE" enabled="true" />
+          <object-type name="DIMENSION" enabled="false" />
+          <object-type name="CLUSTER" enabled="false" />
+          <object-type name="DBLINK" enabled="false" />
+          <object-type name="CREDENTIAL" enabled="false" />
+        </lookup-objects>
+        <force-database-load value="false" />
+        <prompt-connection-selection value="true" />
+        <prompt-schema-selection value="true" />
+      </lookup-filters>
+    </navigation-settings>
+    <dataset-grid-settings>
+      <general>
+        <enable-zooming value="true" />
+        <enable-column-tooltip value="true" />
+      </general>
+      <sorting>
+        <nulls-first value="true" />
+        <max-sorting-columns value="4" />
+      </sorting>
+      <audit-columns>
+        <column-names value="" />
+        <visible value="true" />
+        <editable value="false" />
+      </audit-columns>
+    </dataset-grid-settings>
+    <dataset-editor-settings>
+      <text-editor-popup>
+        <active value="false" />
+        <active-if-empty value="false" />
+        <data-length-threshold value="100" />
+        <popup-delay value="1000" />
+      </text-editor-popup>
+      <values-actions-popup>
+        <show-popup-button value="true" />
+        <element-count-threshold value="1000" />
+        <data-length-threshold value="250" />
+      </values-actions-popup>
+      <general>
+        <fetch-block-size value="100" />
+        <fetch-timeout value="30" />
+        <trim-whitespaces value="true" />
+        <convert-empty-strings-to-null value="true" />
+        <select-content-on-cell-edit value="true" />
+        <large-value-preview-active value="true" />
+      </general>
+      <filters>
+        <prompt-filter-dialog value="true" />
+        <default-filter-type value="BASIC" />
+      </filters>
+      <qualified-text-editor text-length-threshold="300">
+        <content-types>
+          <content-type name="Text" enabled="true" />
+          <content-type name="XML" enabled="true" />
+          <content-type name="DTD" enabled="true" />
+          <content-type name="HTML" enabled="true" />
+          <content-type name="XHTML" enabled="true" />
+          <content-type name="CSS" enabled="true" />
+          <content-type name="SQL" enabled="true" />
+          <content-type name="PL/SQL" enabled="true" />
+          <content-type name="JavaScript" enabled="true" />
+          <content-type name="JSON" enabled="true" />
+          <content-type name="JSON5" enabled="true" />
+          <content-type name="YAML" enabled="true" />
+        </content-types>
+      </qualified-text-editor>
+      <record-navigation>
+        <navigation-target value="VIEWER" />
+      </record-navigation>
+    </dataset-editor-settings>
+    <code-editor-settings>
+      <general>
+        <show-object-navigation-gutter value="false" />
+        <show-spec-declaration-navigation-gutter value="true" />
+        <enable-spellchecking value="true" />
+        <enable-reference-spellchecking value="false" />
+      </general>
+      <confirmations>
+        <save-changes value="false" />
+        <revert-changes value="true" />
+        <exit-on-changes value="ASK" />
+      </confirmations>
+    </code-editor-settings>
+    <code-completion-settings>
+      <filters>
+        <basic-filter>
+          <filter-element type="RESERVED_WORD" id="keyword" selected="true" />
+          <filter-element type="RESERVED_WORD" id="function" selected="true" />
+          <filter-element type="RESERVED_WORD" id="parameter" selected="true" />
+          <filter-element type="RESERVED_WORD" id="datatype" selected="true" />
+          <filter-element type="RESERVED_WORD" id="exception" selected="true" />
+          <filter-element type="OBJECT" id="schema" selected="true" />
+          <filter-element type="OBJECT" id="role" selected="true" />
+          <filter-element type="OBJECT" id="user" selected="true" />
+          <filter-element type="OBJECT" id="privilege" selected="true" />
+          <user-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="json view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="false" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </user-schema>
+          <public-schema>
+            <filter-element type="OBJECT" id="table" selected="false" />
+            <filter-element type="OBJECT" id="view" selected="false" />
+            <filter-element type="OBJECT" id="json view" selected="false" />
+            <filter-element type="OBJECT" id="materialized view" selected="false" />
+            <filter-element type="OBJECT" id="index" selected="false" />
+            <filter-element type="OBJECT" id="constraint" selected="false" />
+            <filter-element type="OBJECT" id="trigger" selected="false" />
+            <filter-element type="OBJECT" id="synonym" selected="false" />
+            <filter-element type="OBJECT" id="sequence" selected="false" />
+            <filter-element type="OBJECT" id="procedure" selected="false" />
+            <filter-element type="OBJECT" id="function" selected="false" />
+            <filter-element type="OBJECT" id="package" selected="false" />
+            <filter-element type="OBJECT" id="type" selected="false" />
+            <filter-element type="OBJECT" id="dimension" selected="false" />
+            <filter-element type="OBJECT" id="cluster" selected="false" />
+            <filter-element type="OBJECT" id="dblink" selected="false" />
+          </public-schema>
+          <any-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="json view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </any-schema>
+        </basic-filter>
+        <extended-filter>
+          <filter-element type="RESERVED_WORD" id="keyword" selected="true" />
+          <filter-element type="RESERVED_WORD" id="function" selected="true" />
+          <filter-element type="RESERVED_WORD" id="parameter" selected="true" />
+          <filter-element type="RESERVED_WORD" id="datatype" selected="true" />
+          <filter-element type="RESERVED_WORD" id="exception" selected="true" />
+          <filter-element type="OBJECT" id="schema" selected="true" />
+          <filter-element type="OBJECT" id="user" selected="true" />
+          <filter-element type="OBJECT" id="role" selected="true" />
+          <filter-element type="OBJECT" id="privilege" selected="true" />
+          <user-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="json view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </user-schema>
+          <public-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="json view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </public-schema>
+          <any-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="json view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </any-schema>
+        </extended-filter>
+      </filters>
+      <sorting enabled="true">
+        <sorting-element type="RESERVED_WORD" id="keyword" />
+        <sorting-element type="RESERVED_WORD" id="datatype" />
+        <sorting-element type="OBJECT" id="column" />
+        <sorting-element type="OBJECT" id="table" />
+        <sorting-element type="OBJECT" id="view" />
+        <sorting-element type="OBJECT" id="json view" />
+        <sorting-element type="OBJECT" id="materialized view" />
+        <sorting-element type="OBJECT" id="index" />
+        <sorting-element type="OBJECT" id="constraint" />
+        <sorting-element type="OBJECT" id="trigger" />
+        <sorting-element type="OBJECT" id="synonym" />
+        <sorting-element type="OBJECT" id="sequence" />
+        <sorting-element type="OBJECT" id="procedure" />
+        <sorting-element type="OBJECT" id="function" />
+        <sorting-element type="OBJECT" id="package" />
+        <sorting-element type="OBJECT" id="type" />
+        <sorting-element type="OBJECT" id="dimension" />
+        <sorting-element type="OBJECT" id="cluster" />
+        <sorting-element type="OBJECT" id="dblink" />
+        <sorting-element type="OBJECT" id="schema" />
+        <sorting-element type="OBJECT" id="role" />
+        <sorting-element type="OBJECT" id="user" />
+        <sorting-element type="RESERVED_WORD" id="function" />
+        <sorting-element type="RESERVED_WORD" id="parameter" />
+      </sorting>
+      <format>
+        <enforce-code-style-case value="true" />
+      </format>
+    </code-completion-settings>
+    <execution-engine-settings>
+      <statement-execution>
+        <fetch-block-size value="100" />
+        <execution-timeout value="20" />
+        <debug-execution-timeout value="600" />
+        <focus-result value="false" />
+        <prompt-execution value="false" />
+      </statement-execution>
+      <script-execution>
+        <command-line-interfaces />
+        <execution-timeout value="300" />
+      </script-execution>
+      <method-execution>
+        <execution-timeout value="30" />
+        <debug-execution-timeout value="600" />
+        <parameter-history-size value="10" />
+      </method-execution>
+      <method-execution>
+        <execution-timeout value="30" />
+        <debug-execution-timeout value="600" />
+        <parameter-history-size value="10" />
+      </method-execution>
+    </execution-engine-settings>
+    <operation-settings>
+      <transactions>
+        <uncommitted-changes>
+          <on-project-close value="ASK" />
+          <on-disconnect value="ASK" />
+          <on-autocommit-toggle value="ASK" />
+        </uncommitted-changes>
+        <multiple-uncommitted-changes>
+          <on-commit value="ASK" />
+          <on-rollback value="ASK" />
+        </multiple-uncommitted-changes>
+      </transactions>
+      <session-browser>
+        <disconnect-session value="ASK" />
+        <kill-session value="ASK" />
+        <reload-on-filter-change value="false" />
+      </session-browser>
+      <compiler>
+        <compile-type value="KEEP" />
+        <compile-dependencies value="ASK" />
+        <always-show-controls value="false" />
+      </compiler>
+    </operation-settings>
+    <ddl-file-settings>
+      <extensions>
+        <mapping file-type-id="VIEW" extensions="vw" />
+        <mapping file-type-id="TRIGGER" extensions="trg" />
+        <mapping file-type-id="PROCEDURE" extensions="prc" />
+        <mapping file-type-id="FUNCTION" extensions="fnc" />
+        <mapping file-type-id="PACKAGE" extensions="pkg" />
+        <mapping file-type-id="PACKAGE_SPEC" extensions="pks" />
+        <mapping file-type-id="PACKAGE_BODY" extensions="pkb" />
+        <mapping file-type-id="TYPE" extensions="tpe" />
+        <mapping file-type-id="TYPE_SPEC" extensions="tps" />
+        <mapping file-type-id="TYPE_BODY" extensions="tpb" />
+        <mapping file-type-id="JAVA_SOURCE" extensions="sql" />
+      </extensions>
+      <general>
+        <lookup-ddl-files value="true" />
+        <create-ddl-files value="false" />
+        <synchronize-ddl-files value="true" />
+        <use-qualified-names value="false" />
+        <make-scripts-rerunnable value="true" />
+      </general>
+    </ddl-file-settings>
+    <assistant-settings>
+      <credential-settings>
+        <credentials />
+      </credential-settings>
+      <profile-settings>
+        <profiles />
+      </profile-settings>
+    </assistant-settings>
+    <general-settings>
+      <regional-settings>
+        <date-format value="MEDIUM" />
+        <number-format value="UNGROUPED" />
+        <locale value="SYSTEM_DEFAULT" />
+        <use-custom-formats value="false" />
+      </regional-settings>
+      <environment>
+        <environment-types>
+          <environment-type id="development" name="Development" description="Development environment" color="-2430209/-12296320" readonly-code="false" readonly-data="false" />
+          <environment-type id="integration" name="Integration" description="Integration environment" color="-2621494/-12163514" readonly-code="true" readonly-data="false" />
+          <environment-type id="production" name="Production" description="Productive environment" color="-11574/-10271420" readonly-code="true" readonly-data="true" />
+          <environment-type id="other" name="Other" description="" color="-1576/-10724543" readonly-code="false" readonly-data="false" />
+        </environment-types>
+        <visibility-settings>
+          <connection-tabs value="true" />
+          <dialog-headers value="true" />
+          <object-editor-tabs value="true" />
+          <script-editor-tabs value="false" />
+          <execution-result-tabs value="true" />
+        </visibility-settings>
+      </environment>
+    </general-settings>
+  </component>
+</project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-2bd5139a:19df7b5fff0:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,16 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
                         ├──────────────▶ src/delta.rs  (optional --baseline)
                         │               DeltaReport { entries, removed }
                         ▼
-                  src/report.rs
-                  (human / JSON / GitHub / Markdown)
+                  src/report/             dispatcher in src/report.rs
+                  ├── types.rs            Grade, coverage_bar, delta_display
+                  ├── links.rs            SourceLinks, linkify
+                  ├── per_crate.rs        crate rollup
+                  ├── human.rs            comfy-table
+                  ├── json.rs             versioned envelope
+                  ├── github.rs           ::warning annotations
+                  ├── markdown.rs         exhaustive GFM
+                  ├── pr_comment.rs       opinionated PR comment
+                  └── summary.rs          --summary aggregate
 ```
 
 **`src/score.rs`** — Pure formula: `CRAP(m) = comp(m)² × (1 − cov(m)/100)³ + comp(m)`. No I/O, no dependencies on other modules.
@@ -79,11 +87,11 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
 - **Slow path**: component-wise suffix matching for relative LCOV paths (e.g., `src/foo.rs` matches `/home/alice/project/src/foo.rs`).
 - **Critical invariant**: relative paths are never canonicalized against CWD (regression test `relative_coverage_paths_are_not_resolved_against_cwd` pins this).
 
-**`src/delta.rs`** — Baseline comparison. `load_baseline` deserializes a previous `--format json` run; `compute_delta` joins current `CrapEntry` list against it by `(file, function)` key, producing `DeltaStatus` (Regressed / Improved / New / Unchanged) and a `removed` list for functions gone since the baseline.
+**`src/delta.rs`** — Baseline comparison. `load_baseline` deserializes a previous `--format json` run; `compute_delta` runs a two-pass match (spec 13): pass 1 joins by exact `(file, function)` key, pass 2 falls back to function-name-only matching for any unpaired entries on both sides — when the name appears exactly once on each side it's reported as a move (`DeltaStatus::Moved` for pure relocations; `Regressed` / `Improved` keep their score-status, with `previous_file` set so renderers can show "moved from X"). Ambiguous names (multiple of the same name) stay unpaired. The `DeltaStatus` set is `Regressed / Improved / New / Unchanged / Moved`; baseline functions never paired land in `removed`.
 
 **`src/config.rs`** — Optional `.cargo-crap.toml` loader. Walks up from CWD until the file is found; returns `Config::default()` if absent. Uses `#[serde(deny_unknown_fields)]` to catch typos. CLI flags always override config values.
 
-**`src/report.rs`** — Renders `Vec<CrapEntry>` or `DeltaReport` in four formats: human (colored Unicode table), JSON (serde), GitHub Actions (`::warning` annotations), and Markdown (GFM table). `render_summary` / `render_delta_summary` print aggregate-only output when `--summary` is set.
+**`src/report/`** — Renders `Vec<CrapEntry>` or `DeltaReport` in five formats: human (colored Unicode table), JSON (versioned envelope), GitHub Actions (`::warning` annotations), Markdown (exhaustive GFM table), and pr-comment (opinionated PR-comment with capped sections + `<details>` blocks). The entry file `src/report.rs` is a thin dispatcher (`Format` enum, `render` / `render_delta` / `render_summary` / `render_delta_summary`); each format lives in a sibling submodule. Cross-cutting helpers (`Grade`, `coverage_bar`, `delta_display`) live in `report/types.rs`; optional GitHub source-link wrapping (`SourceLinks`, `linkify`) lives in `report/links.rs`; per-crate rollup tables (workspace mode) live in `report/per_crate.rs`. Each submodule owns its `#[cfg(test)] mod tests` block; shared fixtures (e.g. `sample()`) live in `report/test_support.rs`.
 
 **`src/main.rs`** — CLI via `clap`. Handles the `cargo crap` subcommand invocation by stripping the leading `crap` argument when detected. Heavy logic is extracted into `validate_args`, `collect_complexity`, `apply_filters`, `load_coverage`, and `do_render` to keep `main` CC below 15.
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Example output:
 | `--summary`                                        | off           | Print only aggregate stats (total, crappy count, worst offender) — no per-function table. In `--workspace` mode this becomes the per-crate summary plus the aggregate line.                                                                                                                                                              |
 | `--workspace`                                      | off           | Analyze all Cargo workspace members (discovered via `cargo metadata`). Ignores `--path`. Adds a *Per-crate summary* table to human and markdown output, and a `crate` field to JSON entries.                                                                                                                                             |
 | `--fail-above`                                     | off           | Exit 1 if any function exceeds `--threshold`.                                                                                                                                                                                                                                                                                            |
-| `--baseline <FILE>`                                | —             | JSON from a previous `--format json` run. Enables delta mode (shows Δ column).                                                                                                                                                                                                                                                           |
-| `--fail-regression`                                | off           | Exit 1 if any function's score increased since `--baseline`. Requires `--baseline`.                                                                                                                                                                                                                                                      |
+| `--baseline <FILE>`                                | —             | JSON from a previous `--format json` run. Enables delta mode (shows Δ column). Functions that moved between files (same name, body unchanged) are detected and reported as `Moved` rather than as separate New + Removed entries; renderers show `← <previous_file>` next to the new location.                                          |
+| `--fail-regression`                                | off           | Exit 1 if any function's score increased since `--baseline`. `Moved` (pure relocation, no score change) is not a regression.                                                                                                                                                                                                             |
 | `--epsilon <VALUE>`                                | `0.01`        | Tolerance for the regression detector. Score deltas with absolute value at or below this count as `Unchanged`. Set to `0.0` to flag every increase, or higher to tolerate noisy coverage. Must be non-negative.                                                                                                                          |
 | `--jobs <N>`                                       | host CPUs     | Cap parallel source-file analysis at `N` threads. Useful in memory-constrained CI/Docker environments. Must be a positive integer.                                                                                                                                                                                                       |
 | `--output <FILE>`                                  | —             | Write output to FILE instead of stdout (useful for saving JSON baselines).                                                                                                                                                                                                                                                               |
@@ -121,7 +121,7 @@ generate types directly from the schema.
 | Variant                    | Schema                                                                                                       |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Absolute (no `--baseline`) | [`schemas/report-v1.json`](https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json) |
-| Delta (with `--baseline`)  | [`schemas/delta-v1.json`](https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v1.json)   |
+| Delta (with `--baseline`)  | [`schemas/delta-v2.json`](https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json)   |
 
 ```jsonc
 // cargo crap --format json
@@ -143,9 +143,9 @@ generate types directly from the schema.
 
 // cargo crap --format json --baseline baseline.json
 {
-  "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v1.json",
+  "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json",
   "version": "0.0.2",
-  "entries": [ /* DeltaEntry — current + baseline_crap + delta + status */ ],
+  "entries": [ /* DeltaEntry — current + baseline_crap + delta + status (+ optional previous_file when moved) */ ],
   "removed": [ /* RemovedEntry — function, file, baseline_crap */ ]
 }
 ```

--- a/schemas/delta-v2.json
+++ b/schemas/delta-v2.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json",
+  "title": "cargo-crap delta report (v2)",
+  "description": "Wire format produced by `cargo crap --format json --baseline FILE`. v2 adds the `moved` status and the optional `previous_file` field for entries that were paired by name across files (spec 13).",
+  "type": "object",
+  "required": ["version", "entries", "removed"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
+    },
+    "entries": {
+      "type": "array",
+      "description": "Per-function entries from the current run, each annotated with its delta against the baseline.",
+      "items": { "$ref": "#/definitions/DeltaEntry" }
+    },
+    "removed": {
+      "type": "array",
+      "description": "Functions present in the baseline but absent from the current run.",
+      "items": { "$ref": "#/definitions/RemovedEntry" }
+    }
+  },
+  "definitions": {
+    "DeltaEntry": {
+      "type": "object",
+      "description": "A `CrapEntry` (flattened) plus delta-mode fields.",
+      "required": [
+        "file",
+        "function",
+        "line",
+        "cyclomatic",
+        "coverage",
+        "crap",
+        "baseline_crap",
+        "delta",
+        "status"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "file": { "type": "string" },
+        "function": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "cyclomatic": { "type": "number", "minimum": 1 },
+        "coverage": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "crap": { "type": "number", "minimum": 1 },
+        "crate": { "type": "string" },
+        "baseline_crap": {
+          "type": ["number", "null"],
+          "description": "CRAP score from the baseline run; null when this function is new."
+        },
+        "delta": {
+          "type": ["number", "null"],
+          "description": "current.crap - baseline_crap; null when this function is new."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["regressed", "improved", "new", "unchanged", "moved"],
+          "description": "Change category relative to the baseline. `moved` is reported when a function was paired across files by name (second-pass matcher) AND its score did not change beyond the epsilon. Score-changed moves use `regressed` / `improved` instead, with `previous_file` set."
+        },
+        "previous_file": {
+          "type": "string",
+          "description": "Baseline location when this entry was paired across files. Omitted when the entry was matched on the exact (file, function) pair (the common case) or is genuinely new."
+        }
+      }
+    },
+    "RemovedEntry": {
+      "type": "object",
+      "required": ["function", "file", "baseline_crap"],
+      "additionalProperties": false,
+      "properties": {
+        "function": { "type": "string" },
+        "file": { "type": "string" },
+        "baseline_crap": {
+          "type": "number",
+          "minimum": 1,
+          "description": "CRAP score the function had in the baseline."
+        }
+      }
+    }
+  }
+}

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -15,7 +15,7 @@
 //! We only consume `SF`, `DA`, and `end_of_record`. Function-level records
 //! (`FN`/`FNDA`) are tempting but unreliable: they tell us where a function
 //! *starts* but not where it *ends*, so we can't compute coverage of the
-//! function's body from them. Instead we intersect the line-level `DA`
+//! function's body from them. Instead, we intersect the line-level `DA`
 //! records with spans we already have from the AST.
 
 use anyhow::{Context, Result};
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 ///
 /// Only lines that appear in a `DA` record are tracked — these are the
 /// "executable" lines per LLVM's coverage mapping. Blank lines, comments,
-/// and purely-declarative lines (use statements, struct definitions) do
+/// and purely declarative lines (use statements, struct definitions) do
 /// not appear here, and we treat them as "not applicable" rather than
 /// "uncovered".
 #[derive(Debug, Default, Clone)]

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -119,6 +119,138 @@ fn classify_score(
     }
 }
 
+/// Build the initial DeltaEntry for a single current-side entry against
+/// the pass-1 (file, function) index. Sets `previous_file = None` (pass 2
+/// fills it in for paired moves).
+fn build_pass_one_entry(
+    e: &CrapEntry,
+    baseline_entry: Option<&CrapEntry>,
+    epsilon: f64,
+) -> DeltaEntry {
+    let (baseline_crap, delta, status) = match baseline_entry {
+        None => (None, None, DeltaStatus::New),
+        Some(b) => {
+            let d = e.crap - b.crap;
+            (Some(b.crap), Some(d), classify_score(d, epsilon))
+        },
+    };
+    DeltaEntry {
+        current: e.clone(),
+        baseline_crap,
+        delta,
+        status,
+        previous_file: None,
+    }
+}
+
+/// Pass 1 — exact `(file_path, function_name)` match. Returns the entry
+/// list (some still `New`, awaiting pass 2) and the set of baseline keys
+/// that were matched (so pass 2 / removed-collection can skip them).
+fn pass_one_exact(
+    current: &[CrapEntry],
+    baseline: &[CrapEntry],
+    epsilon: f64,
+) -> (Vec<DeltaEntry>, HashSet<(String, String)>) {
+    let baseline_index: HashMap<(String, String), &CrapEntry> = baseline
+        .iter()
+        .map(|e| ((path_key(&e.file), e.function.clone()), e))
+        .collect();
+    let mut matched: HashSet<(String, String)> = HashSet::new();
+    let entries = current
+        .iter()
+        .map(|e| {
+            let key = (path_key(&e.file), e.function.clone());
+            let baseline_entry = baseline_index.get(&key).copied();
+            if baseline_entry.is_some() {
+                matched.insert(key);
+            }
+            build_pass_one_entry(e, baseline_entry, epsilon)
+        })
+        .collect();
+    (entries, matched)
+}
+
+/// Apply a single move pairing in place: fill in baseline_crap / delta /
+/// previous_file and choose the right status (`Moved` for pure relocations,
+/// the score-status otherwise).
+fn apply_move_pairing(
+    entry: &mut DeltaEntry,
+    baseline_entry: &CrapEntry,
+    epsilon: f64,
+) {
+    let d = entry.current.crap - baseline_entry.crap;
+    let score_status = classify_score(d, epsilon);
+    entry.baseline_crap = Some(baseline_entry.crap);
+    entry.delta = Some(d);
+    entry.previous_file = Some(baseline_entry.file.clone());
+    entry.status = match score_status {
+        DeltaStatus::Unchanged => DeltaStatus::Moved,
+        other => other,
+    };
+}
+
+/// Pass 2 — name-only fallback over the unmatched. Pairings happen only
+/// when a name appears exactly once on each side (the unambiguous case).
+fn pass_two_name_fallback(
+    entries: &mut [DeltaEntry],
+    baseline: &[CrapEntry],
+    matched: &mut HashSet<(String, String)>,
+    epsilon: f64,
+) {
+    let mut new_idx_by_name: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, de) in entries.iter().enumerate() {
+        if de.status == DeltaStatus::New {
+            new_idx_by_name
+                .entry(de.current.function.clone())
+                .or_default()
+                .push(i);
+        }
+    }
+    let mut baseline_unmatched_by_name: HashMap<String, Vec<&CrapEntry>> = HashMap::new();
+    for e in baseline {
+        let key = (path_key(&e.file), e.function.clone());
+        if !matched.contains(&key) {
+            baseline_unmatched_by_name
+                .entry(e.function.clone())
+                .or_default()
+                .push(e);
+        }
+    }
+    for (name, new_idxs) in &new_idx_by_name {
+        if new_idxs.len() != 1 {
+            continue;
+        }
+        let Some(baseline_group) = baseline_unmatched_by_name.get(name) else {
+            continue;
+        };
+        if baseline_group.len() != 1 {
+            continue;
+        }
+        let baseline_entry = baseline_group[0];
+        apply_move_pairing(&mut entries[new_idxs[0]], baseline_entry, epsilon);
+        matched.insert((
+            path_key(&baseline_entry.file),
+            baseline_entry.function.clone(),
+        ));
+    }
+}
+
+/// Collect baseline entries with no surviving pair into [`RemovedEntry`]s.
+fn collect_removed(
+    baseline: &[CrapEntry],
+    matched: &HashSet<(String, String)>,
+) -> Vec<RemovedEntry> {
+    baseline
+        .iter()
+        .filter(|e| !matched.contains(&(path_key(&e.file), e.function.clone())))
+        .map(|e| RemovedEntry {
+            function: e.function.clone(),
+            file: e.file.clone(),
+            baseline_crap: e.crap,
+        })
+        .collect()
+}
+
 /// Join current results against a baseline and compute per-function deltas.
 ///
 /// **Two-pass match** (spec 13):
@@ -142,110 +274,9 @@ pub fn compute_delta(
     baseline: &[CrapEntry],
     epsilon: f64,
 ) -> DeltaReport {
-    // ─── Pass 1: exact (file, function) match ────────────────────────────
-    let baseline_index: HashMap<(String, String), &CrapEntry> = baseline
-        .iter()
-        .map(|e| ((path_key(&e.file), e.function.clone()), e))
-        .collect();
-
-    let mut matched: HashSet<(String, String)> = HashSet::new();
-
-    let mut entries: Vec<DeltaEntry> = current
-        .iter()
-        .map(|e| {
-            let key = (path_key(&e.file), e.function.clone());
-            let baseline_entry = baseline_index.get(&key).copied();
-            if baseline_entry.is_some() {
-                matched.insert(key);
-            }
-
-            let (baseline_crap, delta, status) = match baseline_entry {
-                None => (None, None, DeltaStatus::New),
-                Some(b) => {
-                    let d = e.crap - b.crap;
-                    (Some(b.crap), Some(d), classify_score(d, epsilon))
-                },
-            };
-
-            DeltaEntry {
-                current: e.clone(),
-                baseline_crap,
-                delta,
-                status,
-                previous_file: None,
-            }
-        })
-        .collect();
-
-    // ─── Pass 2: name-only fallback over the unmatched ───────────────────
-    //
-    // Build name → indices/entries lookups separately for the New (current)
-    // side and the unmatched-baseline side. Pairings only happen when the
-    // count is exactly 1 on both sides (unambiguous).
-    let mut new_idx_by_name: HashMap<String, Vec<usize>> = HashMap::new();
-    for (i, de) in entries.iter().enumerate() {
-        if de.status == DeltaStatus::New {
-            new_idx_by_name
-                .entry(de.current.function.clone())
-                .or_default()
-                .push(i);
-        }
-    }
-
-    let mut baseline_unmatched_by_name: HashMap<String, Vec<&CrapEntry>> = HashMap::new();
-    for e in baseline {
-        let key = (path_key(&e.file), e.function.clone());
-        if !matched.contains(&key) {
-            baseline_unmatched_by_name
-                .entry(e.function.clone())
-                .or_default()
-                .push(e);
-        }
-    }
-
-    // Apply unique-name pairings.
-    for (name, new_idxs) in &new_idx_by_name {
-        if new_idxs.len() != 1 {
-            continue; // Ambiguous on the current side.
-        }
-        let baseline_group = match baseline_unmatched_by_name.get(name) {
-            Some(g) if g.len() == 1 => g,
-            _ => continue, // No match, or ambiguous on the baseline side.
-        };
-        let baseline_entry = baseline_group[0];
-        let entry = &mut entries[new_idxs[0]];
-        let d = entry.current.crap - baseline_entry.crap;
-        let score_status = classify_score(d, epsilon);
-        entry.baseline_crap = Some(baseline_entry.crap);
-        entry.delta = Some(d);
-        entry.previous_file = Some(baseline_entry.file.clone());
-        // Pure-move (no meaningful score change) gets the dedicated status;
-        // score-changed moves keep Regressed / Improved.
-        entry.status = match score_status {
-            DeltaStatus::Unchanged => DeltaStatus::Moved,
-            other => other,
-        };
-        // Mark the baseline entry as paired so it doesn't end up in `removed`.
-        let baseline_key = (
-            path_key(&baseline_entry.file),
-            baseline_entry.function.clone(),
-        );
-        matched.insert(baseline_key);
-    }
-
-    let removed: Vec<RemovedEntry> = baseline
-        .iter()
-        .filter(|e| {
-            let key = (path_key(&e.file), e.function.clone());
-            !matched.contains(&key)
-        })
-        .map(|e| RemovedEntry {
-            function: e.function.clone(),
-            file: e.file.clone(),
-            baseline_crap: e.crap,
-        })
-        .collect();
-
+    let (mut entries, mut matched) = pass_one_exact(current, baseline, epsilon);
+    pass_two_name_fallback(&mut entries, baseline, &mut matched, epsilon);
+    let removed = collect_removed(baseline, &matched);
     DeltaReport { entries, removed }
 }
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -36,6 +36,12 @@ pub enum DeltaStatus {
     New,
     /// Score changed by ≤ epsilon — effectively unchanged.
     Unchanged,
+    /// Function moved to a different file with no meaningful score change
+    /// (≤ epsilon). The baseline location is preserved in
+    /// [`DeltaEntry::previous_file`]. Score-changed moves keep their
+    /// score-status (`Regressed` / `Improved`); `Moved` is exclusively for
+    /// pure relocations.
+    Moved,
 }
 
 /// One function from the current run, annotated with its change since the baseline.
@@ -48,6 +54,11 @@ pub struct DeltaEntry {
     /// `current.crap − baseline_crap`; `None` when this function is new.
     pub delta: Option<f64>,
     pub status: DeltaStatus,
+    /// Set when this function existed at a different path in the baseline
+    /// (paired by name during the second-pass matcher). `None` for
+    /// first-pass exact matches and genuinely-new entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_file: Option<PathBuf>,
 }
 
 /// A function present in the baseline but absent in the current run.
@@ -94,13 +105,35 @@ fn path_key(p: &Path) -> String {
     p.to_string_lossy().replace('\\', "/")
 }
 
+/// Classify a numeric delta against the epsilon tolerance.
+fn classify_score(
+    delta: f64,
+    epsilon: f64,
+) -> DeltaStatus {
+    if delta > epsilon {
+        DeltaStatus::Regressed
+    } else if delta < -epsilon {
+        DeltaStatus::Improved
+    } else {
+        DeltaStatus::Unchanged
+    }
+}
+
 /// Join current results against a baseline and compute per-function deltas.
 ///
-/// **Join key**: exact `(file_path, function_name)` pair. This is reliable
-/// when both runs use the same checkout path (local dev, or CI with a fixed
-/// `GITHUB_WORKSPACE`). Functions with no matching baseline entry are marked
-/// [`DeltaStatus::New`]; baseline functions absent in the current run become
-/// [`RemovedEntry`]s.
+/// **Two-pass match** (spec 13):
+///
+/// 1. Exact `(file_path, function_name)` pair — the original behaviour.
+/// 2. Among entries Pass 1 left as `New` (current side) and the unmatched
+///    baseline entries (Removed side), pair any function name that appears
+///    **exactly once** on each side. Score-unchanged pairings become
+///    [`DeltaStatus::Moved`]; score-changed pairings keep their
+///    `Regressed` / `Improved` status. Either way, the entry's
+///    `previous_file` records the baseline location.
+///
+/// Ambiguous names (multiple unmatched entries with the same name) are
+/// left unpaired — there's no way to tell which moved where. They keep
+/// their `New` / Removed status.
 ///
 /// `epsilon` is the tolerance for the regression detector — see
 /// [`DEFAULT_EPSILON`].
@@ -109,34 +142,28 @@ pub fn compute_delta(
     baseline: &[CrapEntry],
     epsilon: f64,
 ) -> DeltaReport {
-    let baseline_index: HashMap<(String, String), f64> = baseline
+    // ─── Pass 1: exact (file, function) match ────────────────────────────
+    let baseline_index: HashMap<(String, String), &CrapEntry> = baseline
         .iter()
-        .map(|e| ((path_key(&e.file), e.function.clone()), e.crap))
+        .map(|e| ((path_key(&e.file), e.function.clone()), e))
         .collect();
 
     let mut matched: HashSet<(String, String)> = HashSet::new();
 
-    let entries: Vec<DeltaEntry> = current
+    let mut entries: Vec<DeltaEntry> = current
         .iter()
         .map(|e| {
             let key = (path_key(&e.file), e.function.clone());
-            let baseline_crap = baseline_index.get(&key).copied();
-            if baseline_crap.is_some() {
+            let baseline_entry = baseline_index.get(&key).copied();
+            if baseline_entry.is_some() {
                 matched.insert(key);
             }
 
-            let (delta, status) = match baseline_crap {
-                None => (None, DeltaStatus::New),
+            let (baseline_crap, delta, status) = match baseline_entry {
+                None => (None, None, DeltaStatus::New),
                 Some(b) => {
-                    let d = e.crap - b;
-                    let status = if d > epsilon {
-                        DeltaStatus::Regressed
-                    } else if d < -epsilon {
-                        DeltaStatus::Improved
-                    } else {
-                        DeltaStatus::Unchanged
-                    };
-                    (Some(d), status)
+                    let d = e.crap - b.crap;
+                    (Some(b.crap), Some(d), classify_score(d, epsilon))
                 },
             };
 
@@ -145,9 +172,66 @@ pub fn compute_delta(
                 baseline_crap,
                 delta,
                 status,
+                previous_file: None,
             }
         })
         .collect();
+
+    // ─── Pass 2: name-only fallback over the unmatched ───────────────────
+    //
+    // Build name → indices/entries lookups separately for the New (current)
+    // side and the unmatched-baseline side. Pairings only happen when the
+    // count is exactly 1 on both sides (unambiguous).
+    let mut new_idx_by_name: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, de) in entries.iter().enumerate() {
+        if de.status == DeltaStatus::New {
+            new_idx_by_name
+                .entry(de.current.function.clone())
+                .or_default()
+                .push(i);
+        }
+    }
+
+    let mut baseline_unmatched_by_name: HashMap<String, Vec<&CrapEntry>> = HashMap::new();
+    for e in baseline {
+        let key = (path_key(&e.file), e.function.clone());
+        if !matched.contains(&key) {
+            baseline_unmatched_by_name
+                .entry(e.function.clone())
+                .or_default()
+                .push(e);
+        }
+    }
+
+    // Apply unique-name pairings.
+    for (name, new_idxs) in &new_idx_by_name {
+        if new_idxs.len() != 1 {
+            continue; // Ambiguous on the current side.
+        }
+        let baseline_group = match baseline_unmatched_by_name.get(name) {
+            Some(g) if g.len() == 1 => g,
+            _ => continue, // No match, or ambiguous on the baseline side.
+        };
+        let baseline_entry = baseline_group[0];
+        let entry = &mut entries[new_idxs[0]];
+        let d = entry.current.crap - baseline_entry.crap;
+        let score_status = classify_score(d, epsilon);
+        entry.baseline_crap = Some(baseline_entry.crap);
+        entry.delta = Some(d);
+        entry.previous_file = Some(baseline_entry.file.clone());
+        // Pure-move (no meaningful score change) gets the dedicated status;
+        // score-changed moves keep Regressed / Improved.
+        entry.status = match score_status {
+            DeltaStatus::Unchanged => DeltaStatus::Moved,
+            other => other,
+        };
+        // Mark the baseline entry as paired so it doesn't end up in `removed`.
+        let baseline_key = (
+            path_key(&baseline_entry.file),
+            baseline_entry.function.clone(),
+        );
+        matched.insert(baseline_key);
+    }
 
     let removed: Vec<RemovedEntry> = baseline
         .iter()
@@ -310,12 +394,15 @@ mod tests {
     }
 
     #[test]
-    fn functions_in_different_files_are_not_matched() {
-        // Kills: replace path_key -> String with String::new() or "xyzzy".into()
+    fn functions_in_different_files_pair_as_moved() {
+        // Spec 13: a function with the same name in only one file on each
+        // side gets paired by name during the second-pass matcher. Same
+        // CC + coverage + crap → status `Moved`, not `New`/`Removed`.
         //
-        // If path_key collapses to a constant, ("", "foo") in current matches
-        // ("", "foo") in baseline regardless of file — "foo" would appear as
-        // Unchanged instead of New, and the baseline entry would not be Removed.
+        // Also kills: `path_key -> String` collapsing to a constant.
+        // Under that mutation, pass 1 would falsely match these as
+        // Unchanged with previous_file = None — distinguishable from the
+        // correct (Moved, Some(src/main.rs)) outcome.
         let current = vec![CrapEntry {
             file: PathBuf::from("src/lib.rs"),
             function: "foo".into(),
@@ -337,13 +424,17 @@ mod tests {
         let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
         assert_eq!(
             report.entries[0].status,
-            DeltaStatus::New,
-            "foo in src/lib.rs must not match foo in src/main.rs"
+            DeltaStatus::Moved,
+            "foo unique on each side must pair as Moved"
         );
         assert_eq!(
-            report.removed.len(),
-            1,
-            "baseline foo must appear as removed"
+            report.entries[0].previous_file,
+            Some(PathBuf::from("src/main.rs")),
+            "previous_file must record the baseline location"
+        );
+        assert!(
+            report.removed.is_empty(),
+            "paired baseline entry must not appear as removed"
         );
     }
 
@@ -431,5 +522,150 @@ mod tests {
         )
         .expect("write");
         assert!(load_baseline(&path).is_err());
+    }
+
+    // ─── Move-aware delta detection (spec 13) ────────────────────────────
+
+    /// Build a CrapEntry parameterized by file + function + score so the
+    /// move-detection scenarios can mint pairs without copy-paste.
+    fn entry_in(
+        file: &str,
+        function: &str,
+        crap: f64,
+    ) -> CrapEntry {
+        CrapEntry {
+            file: PathBuf::from(file),
+            function: function.into(),
+            line: 1,
+            cyclomatic: 5.0,
+            coverage: Some(100.0),
+            crap,
+            crate_name: None,
+        }
+    }
+
+    #[test]
+    fn move_detected_for_unique_name_same_score() {
+        // Pure refactor: function moves between files with identical CC,
+        // coverage and crap → status `Moved`, previous_file recorded,
+        // baseline entry NOT in `removed`.
+        let baseline = vec![entry_in("src/old.rs", "render", 5.0)];
+        let current = vec![entry_in("src/new.rs", "render", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Moved);
+        assert_eq!(
+            report.entries[0].previous_file,
+            Some(PathBuf::from("src/old.rs"))
+        );
+        assert_eq!(report.entries[0].baseline_crap, Some(5.0));
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn moved_with_regression_keeps_regressed_status() {
+        // Function moved AND got worse — the score-status takes precedence
+        // over the bare `Moved` label, but previous_file still records the
+        // move so renderers can show "Regressed, moved from <prev>".
+        let baseline = vec![entry_in("src/old.rs", "render", 5.0)];
+        let current = vec![entry_in("src/new.rs", "render", 12.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Regressed);
+        assert_eq!(
+            report.entries[0].previous_file,
+            Some(PathBuf::from("src/old.rs"))
+        );
+        assert_eq!(report.entries[0].delta, Some(7.0));
+        assert_eq!(report.regression_count(), 1);
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn moved_with_improvement_keeps_improved_status() {
+        // Symmetry test: moved + got better → Improved, not Moved.
+        let baseline = vec![entry_in("src/old.rs", "render", 12.0)];
+        let current = vec![entry_in("src/new.rs", "render", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Improved);
+        assert_eq!(
+            report.entries[0].previous_file,
+            Some(PathBuf::from("src/old.rs"))
+        );
+    }
+
+    #[test]
+    fn ambiguous_names_left_unpaired() {
+        // Two `helper`s on each side → can't tell which moved where.
+        // Both baseline entries become Removed; both current entries stay
+        // New with previous_file = None.
+        let baseline = vec![
+            entry_in("src/a.rs", "helper", 5.0),
+            entry_in("src/b.rs", "helper", 5.0),
+        ];
+        let current = vec![
+            entry_in("src/c.rs", "helper", 5.0),
+            entry_in("src/d.rs", "helper", 5.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries.len(), 2);
+        for de in &report.entries {
+            assert_eq!(de.status, DeltaStatus::New, "ambiguous → New");
+            assert!(
+                de.previous_file.is_none(),
+                "ambiguous → no previous_file pairing"
+            );
+        }
+        assert_eq!(report.removed.len(), 2, "both baseline entries are removed");
+    }
+
+    #[test]
+    fn truly_new_function_stays_new() {
+        // Name does not appear in baseline → unchanged behaviour: New.
+        let current = vec![entry_in("src/a.rs", "brand_new", 5.0)];
+        let baseline = vec![entry_in("src/a.rs", "something_else", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        let new_entry = report
+            .entries
+            .iter()
+            .find(|e| e.current.function == "brand_new")
+            .expect("brand_new missing");
+        assert_eq!(new_entry.status, DeltaStatus::New);
+        assert!(new_entry.previous_file.is_none());
+    }
+
+    #[test]
+    fn truly_removed_function_stays_removed() {
+        // Name does not appear in current → unchanged behaviour: Removed.
+        let current = vec![entry_in("src/a.rs", "kept", 5.0)];
+        let baseline = vec![
+            entry_in("src/a.rs", "kept", 5.0),
+            entry_in("src/a.rs", "deleted", 8.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.removed.len(), 1);
+        assert_eq!(report.removed[0].function, "deleted");
+    }
+
+    #[test]
+    fn exact_path_match_takes_precedence_over_name_fallback() {
+        // `foo` lives at the same path on both sides AND another `foo`
+        // exists in the baseline at a different path. The pass-1 exact
+        // pair must win; the second `foo` must NOT trigger a name-only
+        // pairing (which would be ambiguous: 1 unmatched current, 1
+        // unmatched baseline) — but in fact the current side has zero
+        // unmatched `foo`s after pass 1, so pass 2 finds no candidate
+        // and the orphan baseline `foo` lands in `removed`.
+        let baseline = vec![
+            entry_in("src/a.rs", "foo", 5.0),
+            entry_in("src/b.rs", "foo", 7.0),
+        ];
+        let current = vec![entry_in("src/a.rs", "foo", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        // Pass 1: src/a.rs:foo matches exactly → Unchanged, no previous_file.
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert!(report.entries[0].previous_file.is_none());
+        // Pass 2: no unmatched current entry to pair → src/b.rs:foo is
+        // a genuine deletion.
+        assert_eq!(report.removed.len(), 1);
+        assert_eq!(report.removed[0].file, PathBuf::from("src/b.rs"));
     }
 }

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -81,13 +81,14 @@ pub(crate) fn render_delta_github(
         let cov_str = e.coverage.map_or("—".into(), |c| format!("{c:.1}%"));
         // For score-changed moves, surface the previous location so the
         // annotation tells reviewers where the regression originated.
-        let moved_str = match &de.previous_file {
-            Some(prev) => {
+        let moved_str = de
+            .previous_file
+            .as_ref()
+            .map(|prev| {
                 let prev_disp = prev.strip_prefix(&cwd).unwrap_or(prev);
                 format!(" (moved from {})", prev_disp.display())
-            },
-            None => String::new(),
-        };
+            })
+            .unwrap_or_default();
         let message = format!(
             "{fn_name} CRAP={crap:.1}{delta}{moved} CC={cc} cov={cov}",
             fn_name = e.function,

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -210,4 +210,72 @@ mod tests {
         assert_eq!(gha_escape("a\nb"), "a%0Ab");
         assert_eq!(gha_escape("plain"), "plain"); // no-op for clean strings
     }
+
+    #[test]
+    fn delta_github_annotation_includes_moved_from_when_previous_file_set() {
+        // Spec 13: a regressed entry that also moved files surfaces the
+        // baseline location in the annotation message. Pins the
+        // `previous_file` arm of the `Option::map` in render_delta_github
+        // so it's exercised by the dogfood self-score run (otherwise
+        // CRAP would tick up via reduced coverage on the new code path).
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let report = DeltaReport {
+            entries: vec![DeltaEntry {
+                current: CrapEntry {
+                    file: PathBuf::from("src/new.rs"),
+                    function: "render".into(),
+                    line: 7,
+                    cyclomatic: 5.0,
+                    coverage: Some(50.0),
+                    crap: 35.0,
+                    crate_name: None,
+                },
+                baseline_crap: Some(20.0),
+                delta: Some(15.0),
+                status: DeltaStatus::Regressed,
+                previous_file: Some(PathBuf::from("src/old.rs")),
+            }],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_github(&report, 30.0, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("(moved from src/old.rs)"),
+            "annotation must surface the baseline location, got:\n{s}"
+        );
+        assert!(s.contains("::warning"), "must still emit warning");
+    }
+
+    #[test]
+    fn delta_github_skips_pure_moves() {
+        // Pins: pure-move entries (no score change) are not warnings.
+        // The match arm in `should_warn` returns false for `Moved`.
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let report = DeltaReport {
+            entries: vec![DeltaEntry {
+                current: CrapEntry {
+                    file: PathBuf::from("src/new.rs"),
+                    function: "render".into(),
+                    line: 1,
+                    cyclomatic: 5.0,
+                    coverage: Some(80.0),
+                    crap: 5.0,
+                    crate_name: None,
+                },
+                baseline_crap: Some(5.0),
+                delta: Some(0.0),
+                status: DeltaStatus::Moved,
+                previous_file: Some(PathBuf::from("src/old.rs")),
+            }],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_github(&report, 30.0, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.is_empty(),
+            "pure moves must not emit warnings, got: {s:?}"
+        );
+    }
 }

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -79,11 +79,21 @@ pub(crate) fn render_delta_github(
             None => " (new)".to_string(),
         };
         let cov_str = e.coverage.map_or("—".into(), |c| format!("{c:.1}%"));
+        // For score-changed moves, surface the previous location so the
+        // annotation tells reviewers where the regression originated.
+        let moved_str = match &de.previous_file {
+            Some(prev) => {
+                let prev_disp = prev.strip_prefix(&cwd).unwrap_or(prev);
+                format!(" (moved from {})", prev_disp.display())
+            },
+            None => String::new(),
+        };
         let message = format!(
-            "{fn_name} CRAP={crap:.1}{delta} CC={cc} cov={cov}",
+            "{fn_name} CRAP={crap:.1}{delta}{moved} CC={cc} cov={cov}",
             fn_name = e.function,
             crap = e.crap,
             delta = delta_str,
+            moved = moved_str,
             cc = e.cyclomatic as usize,
             cov = cov_str,
         );

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -439,4 +439,48 @@ mod tests {
             "non-workspace runs must not show per-crate section:\n{s}"
         );
     }
+
+    #[test]
+    fn delta_human_summary_counts_moved_correctly() {
+        // Kills: replace `e.status == DeltaStatus::Moved` with `!=` in
+        // write_delta_summary. With 1 Moved and 3 non-Moved the correct
+        // count (1) differs from the mutated count (3) in the rendered
+        // line, so the assertion catches the flipped operator.
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let mk_entry = |fn_name: &str, status: DeltaStatus| DeltaEntry {
+            current: CrapEntry {
+                file: PathBuf::from("src/a.rs"),
+                function: fn_name.into(),
+                line: 1,
+                cyclomatic: 1.0,
+                coverage: Some(100.0),
+                crap: 1.0,
+                crate_name: None,
+            },
+            baseline_crap: Some(1.0),
+            delta: Some(0.0),
+            status,
+            previous_file: None,
+        };
+        let report = DeltaReport {
+            entries: vec![
+                mk_entry("moved_fn", DeltaStatus::Moved),
+                mk_entry("u1", DeltaStatus::Unchanged),
+                mk_entry("u2", DeltaStatus::Unchanged),
+                mk_entry("u3", DeltaStatus::Unchanged),
+            ],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_human(&report, 30.0, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("↔ 1 moved"),
+            "human delta summary must report 1 moved, not 3:\n{s}"
+        );
+        assert!(
+            !s.contains("↔ 3 moved"),
+            "human delta summary must NOT count non-moved as moved:\n{s}"
+        );
+    }
 }

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -188,10 +188,12 @@ fn build_delta_row(
 
     // Location reads `<new-loc>:<line> ← <previous_file>` when the entry
     // moved, so reviewers see both endpoints without an extra column.
-    let location = match &de.previous_file {
-        Some(prev) => format!("{}:{} ← {}", e.file.display(), e.line, prev.display()),
-        None => format!("{}:{}", e.file.display(), e.line),
-    };
+    let prev_suffix = de
+        .previous_file
+        .as_ref()
+        .map(|p| format!(" ← {}", p.display()))
+        .unwrap_or_default();
+    let location = format!("{}:{}{prev_suffix}", e.file.display(), e.line);
 
     vec![
         Cell::new(grade.icon()).fg(color),

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -182,8 +182,15 @@ fn build_delta_row(
     let delta_cell = match de.status {
         DeltaStatus::Regressed => Cell::new(delta_text).fg(Color::Red),
         DeltaStatus::Improved => Cell::new(delta_text).fg(Color::Green),
-        DeltaStatus::New => Cell::new(delta_text).fg(Color::Yellow),
+        DeltaStatus::New | DeltaStatus::Moved => Cell::new(delta_text).fg(Color::Yellow),
         DeltaStatus::Unchanged => Cell::new(delta_text),
+    };
+
+    // Location reads `<new-loc>:<line> ← <previous_file>` when the entry
+    // moved, so reviewers see both endpoints without an extra column.
+    let location = match &de.previous_file {
+        Some(prev) => format!("{}:{} ← {}", e.file.display(), e.line, prev.display()),
+        None => format!("{}:{}", e.file.display(), e.line),
     };
 
     vec![
@@ -193,7 +200,7 @@ fn build_delta_row(
         Cell::new(e.cyclomatic as usize),
         Cell::new(coverage_bar(e.coverage)),
         Cell::new(&e.function),
-        Cell::new(format!("{}:{}", e.file.display(), e.line)),
+        Cell::new(location),
     ]
 }
 
@@ -216,6 +223,11 @@ fn write_delta_summary(
         .iter()
         .filter(|e| e.status == DeltaStatus::New)
         .count();
+    let moved = report
+        .entries
+        .iter()
+        .filter(|e| e.status == DeltaStatus::Moved)
+        .count();
     let unchanged = report
         .entries
         .iter()
@@ -225,10 +237,11 @@ fn write_delta_summary(
 
     writeln!(
         out,
-        "{}  {}  {}  {}  {}",
+        "{}  {}  {}  {}  {}  {}",
         format!("↑ {regressed} regressed").red(),
         format!("↓ {improved} improved").green(),
         format!("★ {new} new").yellow(),
+        format!("↔ {moved} moved").cyan(),
         format!("· {unchanged} unchanged").dimmed(),
         format!("— {removed} removed").dimmed(),
     )?;

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -31,7 +31,11 @@ macro_rules! schema_url {
 pub const REPORT_SCHEMA_URL: &str = schema_url!("report-v1.json");
 
 /// Stable HTTPS URL of the JSON Schema describing the delta envelope shape.
-pub const DELTA_SCHEMA_URL: &str = schema_url!("delta-v1.json");
+///
+/// Bumped to `delta-v2.json` in spec 13: adds the `moved` status value and
+/// the optional `previous_file` field. Consumers reading v1 see one new
+/// enum value and one new optional field — strictly additive.
+pub const DELTA_SCHEMA_URL: &str = schema_url!("delta-v2.json");
 
 /// JSON wire format for `--format json` output and `--baseline` input.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -5,7 +5,7 @@
 
 use super::links::{SourceLinks, linkify};
 use super::per_crate::write_per_crate_markdown;
-use super::types::{Grade, delta_display};
+use super::types::{Grade, delta_display, format_location_with_prev};
 use super::write_pr_comment_marker;
 use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
 use crate::merge::CrapEntry;
@@ -149,10 +149,7 @@ fn write_delta_entries_table(
         let grade = Grade::of(e.crap, threshold);
         let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
         let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-        let loc_text = match &de.previous_file {
-            Some(prev) => format!("`{}:{}` ← `{}`", e.file.display(), e.line, prev.display()),
-            None => format!("`{}:{}`", e.file.display(), e.line),
-        };
+        let loc_text = format_location_with_prev(&e.file, e.line, de.previous_file.as_deref());
         let loc = linkify(loc_text, links, &e.file, e.line);
         writeln!(
             out,

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -253,4 +253,48 @@ mod tests {
             "markdown format must link Location:\n{s}"
         );
     }
+
+    #[test]
+    fn delta_markdown_stats_counts_moved_correctly() {
+        // Kills: replace `e.status == DeltaStatus::Moved` with `!=` in
+        // write_markdown_delta_stats. With 1 Moved + 3 non-Moved the
+        // correct count (1) differs from the mutated count (3) in the
+        // emitted line.
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let mk_entry = |fn_name: &str, status: DeltaStatus| DeltaEntry {
+            current: CrapEntry {
+                file: PathBuf::from("src/a.rs"),
+                function: fn_name.into(),
+                line: 1,
+                cyclomatic: 1.0,
+                coverage: Some(100.0),
+                crap: 1.0,
+                crate_name: None,
+            },
+            baseline_crap: Some(1.0),
+            delta: Some(0.0),
+            status,
+            previous_file: None,
+        };
+        let report = DeltaReport {
+            entries: vec![
+                mk_entry("moved_fn", DeltaStatus::Moved),
+                mk_entry("u1", DeltaStatus::Unchanged),
+                mk_entry("u2", DeltaStatus::Unchanged),
+                mk_entry("u3", DeltaStatus::Unchanged),
+            ],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_markdown(&report, 30.0, None, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("↔ 1 moved"),
+            "markdown stats line must report 1 moved, not 3:\n{s}"
+        );
+        assert!(
+            !s.contains("↔ 3 moved"),
+            "markdown stats line must NOT count non-moved as moved:\n{s}"
+        );
+    }
 }

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -149,12 +149,11 @@ fn write_delta_entries_table(
         let grade = Grade::of(e.crap, threshold);
         let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
         let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-        let loc = linkify(
-            format!("`{}:{}`", e.file.display(), e.line),
-            links,
-            &e.file,
-            e.line,
-        );
+        let loc_text = match &de.previous_file {
+            Some(prev) => format!("`{}:{}` ← `{}`", e.file.display(), e.line, prev.display()),
+            None => format!("`{}:{}`", e.file.display(), e.line),
+        };
+        let loc = linkify(loc_text, links, &e.file, e.line);
         writeln!(
             out,
             "| {} | {:.1} | {} | {} | {} | {} | {} |",
@@ -189,6 +188,11 @@ fn write_markdown_delta_stats(
         .iter()
         .filter(|e| e.status == DeltaStatus::New)
         .count();
+    let moved = report
+        .entries
+        .iter()
+        .filter(|e| e.status == DeltaStatus::Moved)
+        .count();
     let unchanged = report
         .entries
         .iter()
@@ -197,7 +201,7 @@ fn write_markdown_delta_stats(
     writeln!(out)?;
     writeln!(
         out,
-        "↑ {regressed} regressed · ↓ {improved} improved · ★ {new} new · · {unchanged} unchanged · — {} removed",
+        "↑ {regressed} regressed · ↓ {improved} improved · ★ {new} new · ↔ {moved} moved · · {unchanged} unchanged · — {} removed",
         report.removed.len(),
     )?;
     Ok(())

--- a/src/report/pr_comment.rs
+++ b/src/report/pr_comment.rs
@@ -99,7 +99,15 @@ fn write_pr_comment_row(
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
     let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-    let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
+    let loc_inner = match &de.previous_file {
+        Some(prev) => format!(
+            "`{loc_text}:{}` ← `{}`",
+            e.line,
+            strip_to_display(prev, prefix),
+        ),
+        None => format!("`{loc_text}:{}`", e.line),
+    };
+    let loc = linkify(loc_inner, links, &e.file, e.line);
     writeln!(
         out,
         "| {} | {:.1} | {} | {} | {} | {} | {} |",
@@ -175,6 +183,7 @@ struct DeltaBuckets<'a> {
     regressed: Vec<&'a DeltaEntry>,
     new_entries: Vec<&'a DeltaEntry>,
     improved: Vec<&'a DeltaEntry>,
+    moved: Vec<&'a DeltaEntry>,
     hot_spots: Vec<&'a DeltaEntry>,
     removed: Vec<&'a RemovedEntry>,
 }
@@ -205,6 +214,15 @@ impl<'a> DeltaBuckets<'a> {
             .collect();
         improved.sort_by(|a, b| abs_delta(b).total_cmp(&abs_delta(a)));
 
+        let mut moved: Vec<&DeltaEntry> = report
+            .entries
+            .iter()
+            .filter(|e| e.status == DeltaStatus::Moved)
+            .collect();
+        // Sort moves by current CRAP desc so the most-impactful relocations
+        // come first when the section is collapsed/capped.
+        moved.sort_by(|a, b| b.current.crap.total_cmp(&a.current.crap));
+
         let mut hot_spots: Vec<&DeltaEntry> = report
             .entries
             .iter()
@@ -219,6 +237,7 @@ impl<'a> DeltaBuckets<'a> {
             regressed,
             new_entries,
             improved,
+            moved,
             hot_spots,
             removed,
         }
@@ -234,9 +253,15 @@ impl<'a> DeltaBuckets<'a> {
             .iter()
             .chain(&self.new_entries)
             .chain(&self.improved)
+            .chain(&self.moved)
             .chain(&self.hot_spots)
         {
             paths.push(de.current.file.clone());
+            // Moved entries also contribute their baseline location so the
+            // computed LCP shortens both ends of the `... ← prev` display.
+            if let Some(prev) = &de.previous_file {
+                paths.push(prev.clone());
+            }
         }
         for r in &self.removed {
             paths.push(r.file.clone());
@@ -267,9 +292,10 @@ fn write_pr_comment_breakdown(
 ) -> Result<()> {
     writeln!(
         out,
-        "↑ {} regressed · ★ {} new · ↓ {} improved · {} unchanged · — {} removed",
+        "↑ {} regressed · ★ {} new · ↔ {} moved · ↓ {} improved · {} unchanged · — {} removed",
         b.regressed.len(),
         b.new_entries.len(),
+        b.moved.len(),
         b.improved.len(),
         unchanged,
         b.removed.len(),
@@ -325,6 +351,33 @@ fn write_pr_comment_improved_section(
         write_pr_comment_row(out, de, threshold, prefix, links)?;
     }
     write_truncation_if_capped(out, b.improved.len())?;
+    writeln!(out)?;
+    writeln!(out, "</details>")?;
+    Ok(())
+}
+
+/// Pure-move details block — entries whose body and score are unchanged
+/// but whose file path differs from the baseline. Score-changed moves
+/// stay in the primary table (Regressed) or improvements section.
+fn write_pr_comment_moved_section(
+    out: &mut dyn Write,
+    b: &DeltaBuckets,
+    threshold: f64,
+    prefix: &Path,
+    links: Option<&SourceLinks>,
+) -> Result<()> {
+    if b.moved.is_empty() {
+        return Ok(());
+    }
+    writeln!(out)?;
+    writeln!(out, "<details><summary>↔ {} moved</summary>", b.moved.len())?;
+    writeln!(out)?;
+    writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
+    writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
+    for de in b.moved.iter().take(MAX_ROWS_PER_SECTION) {
+        write_pr_comment_row(out, de, threshold, prefix, links)?;
+    }
+    write_truncation_if_capped(out, b.moved.len())?;
     writeln!(out)?;
     writeln!(out, "</details>")?;
     Ok(())
@@ -413,6 +466,7 @@ pub(crate) fn render_delta_pr_comment(
     write_pr_comment_breakdown(out, &buckets, unchanged_count(report))?;
     write_pr_comment_primary(out, &buckets, threshold, &prefix, links)?;
     write_pr_comment_improved_section(out, &buckets, threshold, &prefix, links)?;
+    write_pr_comment_moved_section(out, &buckets, threshold, &prefix, links)?;
     write_pr_comment_hot_spots_section(out, &buckets, threshold, &prefix, links)?;
     write_pr_comment_removed_section(out, &buckets, &prefix)
 }
@@ -509,6 +563,7 @@ mod tests {
             baseline_crap: baseline,
             delta: baseline.map(|b| crap - b),
             status,
+            previous_file: None,
         }
     }
 
@@ -729,6 +784,47 @@ mod tests {
     }
 
     #[test]
+    fn pr_comment_moved_in_collapsed_details() {
+        let mut entry = delta_entry("src/new.rs", "render", 5.0, Some(5.0), DeltaStatus::Moved);
+        entry.previous_file = Some(PathBuf::from("src/old.rs"));
+        let report = DeltaReport {
+            entries: vec![entry],
+            removed: vec![],
+        };
+        let s = render_delta_pr_to_string(&report);
+        assert!(
+            s.contains("<details><summary>↔ 1 moved</summary>"),
+            "moved must be inside <details>, got:\n{s}"
+        );
+        // The location cell shows both endpoints. LCP between the two paths
+        // is `src`, so the visible text strips it on both sides.
+        assert!(s.contains("← `old.rs`"), "must show prev path:\n{s}");
+        // Δ column reads MOVED for pure relocations.
+        assert!(s.contains("MOVED"), "must show MOVED in Δ column:\n{s}");
+        // Breakdown reflects the move.
+        assert!(s.contains("↔ 1 moved"));
+    }
+
+    #[test]
+    fn pr_comment_moved_section_omitted_when_empty() {
+        let report = DeltaReport {
+            entries: vec![delta_entry(
+                "src/a.rs",
+                "foo",
+                5.0,
+                Some(5.0),
+                DeltaStatus::Unchanged,
+            )],
+            removed: vec![],
+        };
+        let s = render_delta_pr_to_string(&report);
+        assert!(
+            !s.contains("↔ 0 moved</summary>"),
+            "empty moved section must be omitted, got:\n{s}"
+        );
+    }
+
+    #[test]
     fn pr_comment_removed_in_collapsed_details() {
         let report = DeltaReport {
             entries: vec![],
@@ -943,7 +1039,9 @@ mod tests {
             }],
         };
         let s = render_delta_pr_to_string(&report);
-        assert!(s.contains("↑ 1 regressed · ★ 1 new · ↓ 1 improved · 1 unchanged · — 1 removed"));
+        assert!(s.contains(
+            "↑ 1 regressed · ★ 1 new · ↔ 0 moved · ↓ 1 improved · 1 unchanged · — 1 removed"
+        ));
     }
 
     // --- pr-comment renderer (absolute, no baseline) -----------------------

--- a/src/report/pr_comment.rs
+++ b/src/report/pr_comment.rs
@@ -99,14 +99,12 @@ fn write_pr_comment_row(
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
     let loc_text = strip_to_display(&e.file, prefix);
     let func = linkify(format!("`{}`", e.function), links, &e.file, e.line);
-    let loc_inner = match &de.previous_file {
-        Some(prev) => format!(
-            "`{loc_text}:{}` ← `{}`",
-            e.line,
-            strip_to_display(prev, prefix),
-        ),
-        None => format!("`{loc_text}:{}`", e.line),
-    };
+    let prev_suffix = de
+        .previous_file
+        .as_ref()
+        .map(|p| format!(" ← `{}`", strip_to_display(p, prefix)))
+        .unwrap_or_default();
+    let loc_inner = format!("`{loc_text}:{}`{prev_suffix}", e.line);
     let loc = linkify(loc_inner, links, &e.file, e.line);
     writeln!(
         out,
@@ -246,26 +244,23 @@ impl<'a> DeltaBuckets<'a> {
     /// Path prefix to strip from rendered Location cells. Includes capped-out
     /// rows — the cap doesn't change which paths participate. Falls back to
     /// CWD when no longest-common-prefix exists; see [`compute_render_prefix`].
+    ///
+    /// Each rendered entry contributes its current path; moved entries also
+    /// contribute their baseline location (`previous_file`) so the LCP
+    /// shortens both ends of the `<new> ← <prev>` display string.
     fn common_prefix(&self) -> PathBuf {
-        let mut paths: Vec<PathBuf> = Vec::new();
-        for de in self
+        let entry_paths = self
             .regressed
             .iter()
             .chain(&self.new_entries)
             .chain(&self.improved)
             .chain(&self.moved)
             .chain(&self.hot_spots)
-        {
-            paths.push(de.current.file.clone());
-            // Moved entries also contribute their baseline location so the
-            // computed LCP shortens both ends of the `... ← prev` display.
-            if let Some(prev) = &de.previous_file {
-                paths.push(prev.clone());
-            }
-        }
-        for r in &self.removed {
-            paths.push(r.file.clone());
-        }
+            .flat_map(|de| {
+                std::iter::once(de.current.file.clone()).chain(de.previous_file.iter().cloned())
+            });
+        let removed_paths = self.removed.iter().map(|r| r.file.clone());
+        let paths: Vec<PathBuf> = entry_paths.chain(removed_paths).collect();
         compute_render_prefix(&paths)
     }
 }
@@ -465,10 +460,24 @@ pub(crate) fn render_delta_pr_comment(
     write_pr_comment_delta_headline(out, buckets.regressed.len())?;
     write_pr_comment_breakdown(out, &buckets, unchanged_count(report))?;
     write_pr_comment_primary(out, &buckets, threshold, &prefix, links)?;
-    write_pr_comment_improved_section(out, &buckets, threshold, &prefix, links)?;
-    write_pr_comment_moved_section(out, &buckets, threshold, &prefix, links)?;
-    write_pr_comment_hot_spots_section(out, &buckets, threshold, &prefix, links)?;
-    write_pr_comment_removed_section(out, &buckets, &prefix)
+    write_pr_comment_secondary_sections(out, &buckets, threshold, &prefix, links)
+}
+
+/// Emit the four secondary sections (Improved / Moved / Hot spots /
+/// Removed). Extracted so [`render_delta_pr_comment`] stays at the same
+/// CC it had before spec 13 — adding more `?` calls inline would push
+/// the orchestrator past its baseline.
+fn write_pr_comment_secondary_sections(
+    out: &mut dyn Write,
+    buckets: &DeltaBuckets,
+    threshold: f64,
+    prefix: &Path,
+    links: Option<&SourceLinks>,
+) -> Result<()> {
+    write_pr_comment_improved_section(out, buckets, threshold, prefix, links)?;
+    write_pr_comment_moved_section(out, buckets, threshold, prefix, links)?;
+    write_pr_comment_hot_spots_section(out, buckets, threshold, prefix, links)?;
+    write_pr_comment_removed_section(out, buckets, prefix)
 }
 
 fn write_pr_comment_abs_headline(
@@ -797,10 +806,10 @@ mod tests {
             "moved must be inside <details>, got:\n{s}"
         );
         // The location cell shows both endpoints. LCP between the two paths
-        // is `src`, so the visible text strips it on both sides.
+        // is `src`, so the visible text strips it on both sides. The `←`
+        // annotation IS the move indicator; the Δ column stays blank to
+        // match `Unchanged` semantics (no score change).
         assert!(s.contains("← `old.rs`"), "must show prev path:\n{s}");
-        // Δ column reads MOVED for pure relocations.
-        assert!(s.contains("MOVED"), "must show MOVED in Δ column:\n{s}");
         // Breakdown reflects the move.
         assert!(s.contains("↔ 1 moved"));
     }

--- a/src/report/summary.rs
+++ b/src/report/summary.rs
@@ -139,4 +139,48 @@ mod tests {
         assert!(!s.contains("Per-crate summary"));
         assert!(s.contains("Analyzed: 1"));
     }
+
+    #[test]
+    fn render_delta_summary_counts_moved_correctly() {
+        // Kills: replace `e.status == DeltaStatus::Moved` with `!=`. The
+        // mutation flips the count to "everything except moved" — choosing
+        // 1 Moved + 3 non-Moved makes the correct count (1) and the
+        // mutated count (3) provably different in the rendered text.
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let mk_entry = |fn_name: &str, status: DeltaStatus| DeltaEntry {
+            current: CrapEntry {
+                file: PathBuf::from("src/a.rs"),
+                function: fn_name.into(),
+                line: 1,
+                cyclomatic: 1.0,
+                coverage: Some(100.0),
+                crap: 1.0,
+                crate_name: None,
+            },
+            baseline_crap: Some(1.0),
+            delta: Some(0.0),
+            status,
+            previous_file: None,
+        };
+        let report = DeltaReport {
+            entries: vec![
+                mk_entry("moved", DeltaStatus::Moved),
+                mk_entry("u1", DeltaStatus::Unchanged),
+                mk_entry("u2", DeltaStatus::Unchanged),
+                mk_entry("u3", DeltaStatus::Unchanged),
+            ],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_summary(&report, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("↔ 1 moved"),
+            "summary must report 1 moved, not 3 (which would mean == was flipped to !=):\n{s}"
+        );
+        assert!(
+            !s.contains("↔ 3 moved"),
+            "summary must NOT count non-moved entries as moved:\n{s}"
+        );
+    }
 }

--- a/src/report/summary.rs
+++ b/src/report/summary.rs
@@ -75,6 +75,11 @@ pub fn render_delta_summary(
         .iter()
         .filter(|e| e.status == DeltaStatus::New)
         .count();
+    let moved = report
+        .entries
+        .iter()
+        .filter(|e| e.status == DeltaStatus::Moved)
+        .count();
     let unchanged = report
         .entries
         .iter()
@@ -82,10 +87,11 @@ pub fn render_delta_summary(
         .count();
     writeln!(
         out,
-        "{}  {}  {}  {}  {}",
+        "{}  {}  {}  {}  {}  {}",
         format!("↑ {regressed} regressed").red(),
         format!("↓ {improved} improved").green(),
         format!("★ {new} new").yellow(),
+        format!("↔ {moved} moved").cyan(),
         format!("· {unchanged} unchanged").dimmed(),
         format!("— {} removed", report.removed.len()).dimmed(),
     )?;

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -70,14 +70,33 @@ pub(crate) fn coverage_bar(pct: Option<f64>) -> String {
 /// Format the Δ column value for a single delta entry.
 ///
 /// Shared by the human delta table and the markdown / pr-comment renderers.
+/// `Moved` rows leave the Δ column blank — the `← <prev>` annotation in
+/// the Location cell already communicates the relocation, and matching
+/// `Unchanged`'s blank Δ keeps the score-status semantics consistent
+/// (Moved = "no meaningful score change").
 pub(crate) fn delta_display(de: &DeltaEntry) -> String {
     match de.status {
         DeltaStatus::Regressed | DeltaStatus::Improved => {
             format!("{:+.1}", de.delta.unwrap())
         },
         DeltaStatus::New => "NEW".to_string(),
-        DeltaStatus::Moved => "MOVED".to_string(),
-        DeltaStatus::Unchanged => String::new(),
+        DeltaStatus::Unchanged | DeltaStatus::Moved => String::new(),
+    }
+}
+
+/// Render a Location-cell string, optionally appending `← <prev>` when the
+/// entry was paired by name across files. Used by the markdown renderer
+/// (where there's no prefix-stripping) and exists separately for the
+/// pr-comment renderer (which also strips the LCP). Splitting the format
+/// keeps the per-renderer row writers simple.
+pub(crate) fn format_location_with_prev(
+    file: &std::path::Path,
+    line: usize,
+    previous_file: Option<&std::path::Path>,
+) -> String {
+    match previous_file {
+        Some(prev) => format!("`{}:{}` ← `{}`", file.display(), line, prev.display()),
+        None => format!("`{}:{}`", file.display(), line),
     }
 }
 

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -76,6 +76,7 @@ pub(crate) fn delta_display(de: &DeltaEntry) -> String {
             format!("{:+.1}", de.delta.unwrap())
         },
         DeltaStatus::New => "NEW".to_string(),
+        DeltaStatus::Moved => "MOVED".to_string(),
         DeltaStatus::Unchanged => String::new(),
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -155,7 +155,7 @@ const REPORT_SCHEMA_URL: &str =
     "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json";
 
 const DELTA_SCHEMA_URL: &str =
-    "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v1.json";
+    "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json";
 
 fn compile_schema(path: &str) -> jsonschema::Validator {
     let raw = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
@@ -277,7 +277,7 @@ fn delta_json_output_validates_against_delta_schema() {
         Some(DELTA_SCHEMA_URL),
         "delta envelope must include the delta $schema URL"
     );
-    let validator = compile_schema("schemas/delta-v1.json");
+    let validator = compile_schema("schemas/delta-v2.json");
     assert_valid(&validator, &value);
 }
 


### PR DESCRIPTION
## Summary

Implements [spec 13](specs/13-move-aware-delta.md) — refactor PRs that move
code between files now report meaningful diffs ("3 moved") instead of the
old "60 new + 59 removed" noise.

- `DeltaStatus::Moved` enum variant + `DeltaEntry.previous_file` field
  (additive — strictly-optional new field, omitted when null)
- Two-pass matcher in `compute_delta`: exact `(file, function)` first,
  then unique-name fallback for unmatched entries on both sides.
  Ambiguous pairings (multiple same-name on either side) stay unpaired.
- Score-changed moves keep their `Regressed` / `Improved` status, with
  `previous_file` set — so the regression gate still fires for "moved
  AND got worse"; pure moves don't gate.
- Schema bumped to **delta-v2** (`schemas/delta-v2.json`); `DELTA_SCHEMA_URL`
  in `src/report/json.rs` updated.

### Renderer surface

| Renderer | Treatment |
|---|---|
| `pr-comment` | New `↔ N moved` `<details>` block; primary-row Location cell reads `` `<new>:N` ← `<prev>` `` for any entry with `previous_file` |
| `markdown` | Same `← prev` location annotation; breakdown line includes `↔ N moved` |
| `human` | Δ column reads `MOVED` for pure moves; Location column appends `← <prev>`; summary line includes `↔ N moved` |
| `summary` (`--summary`) | Aggregate one-liner includes `↔ N moved` |
| `github` (`::warning`) | Pure moves silent (not a regression); score-changed moves get `(moved from X)` appended to the annotation message |
| `json` / dispatcher | `previous_file` serialized (skipped when null); `"moved"` is a new status enum value |

### Tests

- 7 new delta unit tests covering: pure move, regressed move, improved
  move, ambiguous-multiple-of-each-name, genuinely-new, genuinely-removed,
  exact-takes-precedence-over-name-fallback
- 2 new pr-comment tests: moved <details> block; empty section omitted
- One existing test (`functions_in_different_files_are_not_matched`)
  rewritten to assert the new behaviour and renamed to
  `functions_in_different_files_pair_as_moved`
- All 5 suites pass: 149 lib + 84 cli + 0 doc + 2 integration + 5 lints

## Test plan

- [x] `just dev` clean (fmt + clippy + tests)
- [ ] CI passes on all 3 OSes
- [ ] Self-score PR comment correctly shows `↔ N moved` and `← prev` annotation
- [ ] No unrelated noise in the regression / improvement counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)