### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.0] - 2026-05-07
+
+First release with stable PR-comment workflow, versioned JSON output, and
+move-aware delta detection. Anchor for early-adopter use.
+
+### Added
+
+- **Automatic PR comments** (`--format pr-comment`, spec 11). Opinionated
+  GitHub comment that hides Unchanged rows, caps each section at 25 rows,
+  and tucks Improved / Hot-spots / Removed into collapsed `<details>`
+  blocks. CI updates a single sticky comment via a hidden HTML marker.
+- **Clickable source links** in pr-comment / markdown output (spec 12).
+  When `--repo-url` and `--commit-ref` are provided (or
+  `GITHUB_SERVER_URL` + `GITHUB_REPOSITORY` + `GITHUB_SHA` env vars on
+  GitHub Actions), Function and Location cells become markdown links to
+  the file at that commit. URLs use forward slashes on every host OS.
+- **Move-aware delta detection** (spec 13). `compute_delta` runs a
+  two-pass match: exact `(file, function)` first, then unique-name
+  fallback for unpaired entries on both sides. Unambiguous moves with
+  no score change report as a new `DeltaStatus::Moved`; score-changed
+  moves keep `Regressed` / `Improved` and carry `previous_file` so
+  renderers can show "moved from X". Refactor PRs no longer report
+  noisy "N new + N removed" diffs.
+- **Per-crate rollup** for `--workspace` runs (spec 05). Human and
+  markdown formats lead with a per-crate summary table; JSON entries
+  carry a `crate` field.
+- **`--jobs <N>`** flag (spec 04) — caps parallel source-file analysis,
+  useful in memory-constrained CI / Docker environments.
+- **`--epsilon <VALUE>`** flag (spec 08) — tunable tolerance for the
+  regression detector. Defaults to `0.01`; set to `0.0` to flag every
+  increase, or higher to ignore noisy coverage drift.
+- **Versioned JSON envelope** (spec 02). Output is `{ $schema, version,
+  entries }` with the schema URL pointing at the published JSON Schema.
+  Bare-array baselines from older runs must be regenerated.
+- **Published JSON Schemas** (spec 03) — `report-v1.json` for absolute
+  output, `delta-v2.json` for delta output. Both stable HTTPS URLs.
+- **Unmatched-LCOV warning** — emit a stderr warning listing source
+  files with no matching LCOV entry, so `--lcov` typos fail loudly
+  instead of producing silently-wrong scores.
+
+### Changed
+
+- **`src/report.rs` split** into `src/report/<submodule>.rs` (one file
+  per renderer + shared helpers). Public API unchanged.
+- **JSON delta schema bumped** to `delta-v2.json` (additive — `moved`
+  status value + optional `previous_file` field). v1 consumers see a
+  new optional field they can ignore.
+- **MSRV** bumped to Rust **1.88**.
+- **`thiserror`** dependency removed (was unused).
+
+### Fixed
+
+- pr-comment Location cell falls back to CWD-stripping when no
+  longest-common-prefix exists across rendered paths (so single-entry
+  CI runs read `src/foo.rs:N` instead of `/home/runner/...:N`).
+- Windows delta paths are normalized so backslashes don't leak into
+  GitHub source-link URLs (which require forward slashes).
+
+### Schema migration
+
+Consumers reading `--format json --baseline ...` should switch to
+`schemas/delta-v2.json`. The v1 schema URL still resolves but new
+output points at v2.
+
+
 ## [0.0.1] - 2026-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["cargo-crap contributors"]

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -297,4 +297,59 @@ mod tests {
             "markdown stats line must NOT count non-moved as moved:\n{s}"
         );
     }
+
+    #[test]
+    fn delta_markdown_location_uses_format_location_with_prev_helper() {
+        // Kills: replace `format_location_with_prev -> String` with
+        // `String::new()` or `"xyzzy".into()`. The helper is the only
+        // producer of the Location backtick text in delta-markdown rows;
+        // checking for the exact `<file>:<line>` and `<file>:<line> ← <prev>`
+        // strings catches both stub mutants.
+        use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
+        let regular = DeltaEntry {
+            current: CrapEntry {
+                file: PathBuf::from("src/a.rs"),
+                function: "fn_a".into(),
+                line: 7,
+                cyclomatic: 1.0,
+                coverage: Some(100.0),
+                crap: 1.0,
+                crate_name: None,
+            },
+            baseline_crap: Some(1.0),
+            delta: Some(0.0),
+            status: DeltaStatus::Unchanged,
+            previous_file: None,
+        };
+        let moved = DeltaEntry {
+            current: CrapEntry {
+                file: PathBuf::from("src/new.rs"),
+                function: "fn_b".into(),
+                line: 42,
+                cyclomatic: 1.0,
+                coverage: Some(100.0),
+                crap: 1.0,
+                crate_name: None,
+            },
+            baseline_crap: Some(1.0),
+            delta: Some(0.0),
+            status: DeltaStatus::Moved,
+            previous_file: Some(PathBuf::from("src/old.rs")),
+        };
+        let report = DeltaReport {
+            entries: vec![regular, moved],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_markdown(&report, 30.0, None, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("`src/a.rs:7`"),
+            "non-moved row must show `<file>:<line>` location, got:\n{s}"
+        );
+        assert!(
+            s.contains("`src/new.rs:42` ← `src/old.rs`"),
+            "moved row must show `<new>:<line> ← <prev>` location, got:\n{s}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

First release with stable PR-comment workflow, versioned JSON output, and
move-aware delta detection. Anchor for early-adopter use.

- Bump `Cargo.toml` version: **0.0.2 → 0.1.0**
- Add `CHANGELOG.md` entry covering everything since 0.0.2

### What's in 0.1.0

| Spec | What |
|---|---|
| 02 | Versioned JSON envelope (`$schema`, `version`, `entries`) |
| 03 | Published JSON Schemas (stable HTTPS URLs) |
| 04 | `--jobs <N>` flag for memory-constrained CI |
| 05 | Per-crate rollup table for `--workspace` runs |
| 08 | `--epsilon <VALUE>` tunable regression tolerance |
| 11 | Automatic PR comments (`--format pr-comment`) |
| 12 | Clickable source links in pr-comment / markdown |
| 13 | Move-aware delta detection (new `Moved` status + `previous_file`) |

Plus internal refactor: `src/report.rs` → `src/report/<submodule>.rs`
(public API unchanged).

### Schema migration

JSON delta consumers should switch to **`delta-v2.json`** —
strictly additive vs v1 (`moved` status value + optional
`previous_file` field).

### Bonus mutants fix

Folds in a new test
(`delta_markdown_location_uses_format_location_with_prev_helper`)
that kills two `format_location_with_prev` mutants the post-merge
mutants run flagged on main right after spec 13 landed. No
behavior change.

## Test plan

- [x] `just dev-mutants-diff` — 19/19 mutants caught locally
- [ ] Self-score green on this PR
- [ ] Mutation tests green on this PR
- [ ] After merge: tag `v0.1.0` and let `release.yml` publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)