### PR TITLE
feat(report): SARIF 2.1.0 output (spec 07)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Example output:
 | `--missing {pessimistic,optimistic,skip}`          | `pessimistic` | How to score a function with no coverage data.                                                                                                                                                                                                                                                                                           |
 | `--exclude <GLOB>`                                 | —             | Skip files matching this pattern (repeatable). `**` crosses directories.                                                                                                                                                                                                                                                                 |
 | `--allow <GLOB>`                                   | —             | Suppress functions whose names match this pattern (repeatable). `*` matches `::`.                                                                                                                                                                                                                                                        |
-| `--format {human,json,github,markdown,pr-comment}` | `human`       | Output format. `json` emits a versioned envelope (see [JSON output schema](#json-output-schema) below). `github` emits `::warning` annotations. `markdown` emits a GFM table (exhaustive). `pr-comment` is the opinionated PR-bot variant: hides unchanged rows, caps each section, collapses non-critical info into `<details>` blocks. |
+| `--format {human,json,github,markdown,pr-comment,sarif}` | `human`       | Output format. `json` emits a versioned envelope (see [JSON output schema](#json-output-schema) below). `github` emits `::warning` annotations. `markdown` emits a GFM table (exhaustive). `pr-comment` is the opinionated PR-bot variant: hides unchanged rows, caps each section, collapses non-critical info into `<details>` blocks. `sarif` emits SARIF 2.1.0 JSON for upload to GitHub Code Scanning, VS Code, and other static-analysis tooling (see [SARIF output](#sarif-output) below). |
 | `--summary`                                        | off           | Print only aggregate stats (total, crappy count, worst offender) — no per-function table. In `--workspace` mode this becomes the per-crate summary plus the aggregate line.                                                                                                                                                              |
 | `--workspace`                                      | off           | Analyze all Cargo workspace members (discovered via `cargo metadata`). Ignores `--path`. Adds a *Per-crate summary* table to human and markdown output, and a `crate` field to JSON entries.                                                                                                                                             |
 | `--fail-above`                                     | off           | Exit 1 if any function exceeds `--threshold`.                                                                                                                                                                                                                                                                                            |
@@ -152,6 +152,21 @@ generate types directly from the schema.
 
 `--baseline` only reads files in this envelope shape; bare-array baselines
 from older runs must be regenerated.
+
+### SARIF output
+
+`--format sarif` emits a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+JSON document — the format consumed by GitHub Code Scanning, VS Code,
+rust-analyzer, and most static-analysis tooling.
+
+- Each crappy function (entry above `--threshold`) becomes one
+  `result` with `level: "warning"` and a physical location pointing at
+  the function's start line.
+- Functions below the threshold are not included.
+- An empty result set still produces a valid SARIF document with the
+  full `runs[0].tool.driver` envelope.
+- `--baseline` is rejected with `--format sarif`; SARIF describes
+  findings, not deltas. Use `--format json` for delta output.
 
 ## Configuration file
 
@@ -272,6 +287,25 @@ they are introduced, not weeks later.
     path: baseline
 - run: cargo llvm-cov --lcov --output-path lcov.info
 - run: cargo crap --lcov lcov.info --baseline baseline/baseline.json --fail-regression
+```
+
+### GitHub Code Scanning (SARIF)
+
+Upload `--format sarif` output to surface crappy functions in the
+repository's **Security → Code scanning** tab. The job needs
+`security-events: write`.
+
+```yaml
+self_score:
+  permissions:
+    security-events: write
+  steps:
+    - run: cargo llvm-cov --lcov --output-path lcov.info
+    - run: cargo crap --lcov lcov.info --format sarif --output crap.sarif
+    - uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: crap.sarif
+        category: cargo-crap
 ```
 
 ### PR comment bot

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,10 @@ enum FormatArg {
     /// section, collapses non-critical info into `<details>` blocks. Designed
     /// for the GitHub PR comment use case where readability beats completeness.
     PrComment,
+    /// SARIF 2.1.0 JSON for upload to GitHub Code Scanning, VS Code, and
+    /// other static-analysis tools. Each crappy function becomes one
+    /// warning-level result. Incompatible with `--baseline`.
+    Sarif,
 }
 
 impl From<FormatArg> for Format {
@@ -187,6 +191,7 @@ impl From<FormatArg> for Format {
             FormatArg::Github => Self::GitHub,
             FormatArg::Markdown => Self::Markdown,
             FormatArg::PrComment => Self::PrComment,
+            FormatArg::Sarif => Self::Sarif,
         }
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -18,7 +18,7 @@
 use crate::delta::DeltaReport;
 use crate::merge::CrapEntry;
 use crate::score::Severity;
-use anyhow::Result;
+use anyhow::{Result, bail};
 use std::io::Write;
 
 mod github;
@@ -28,6 +28,7 @@ mod links;
 mod markdown;
 mod per_crate;
 mod pr_comment;
+mod sarif;
 mod summary;
 mod types;
 
@@ -60,6 +61,11 @@ pub enum Format {
     /// improvements / removed / hot-spots into collapsed `<details>` blocks.
     /// Capped per section. Use `Markdown` for the exhaustive report.
     PrComment,
+    /// SARIF 2.1.0 JSON — the format consumed by GitHub Code Scanning,
+    /// VS Code, rust-analyzer, and most static-analysis tooling. Each
+    /// crappy function becomes one `result` with `level: "warning"`,
+    /// pointing at the function's start line.
+    Sarif,
 }
 
 /// Render `entries` in the requested format to `out`.
@@ -80,6 +86,7 @@ pub fn render(
         Format::GitHub => github::render_github(entries, threshold, out),
         Format::Markdown => markdown::render_markdown(entries, threshold, links, out),
         Format::PrComment => pr_comment::render_pr_comment(entries, threshold, links, out),
+        Format::Sarif => sarif::render_sarif(entries, threshold, out),
     }
 }
 
@@ -101,6 +108,13 @@ pub fn render_delta(
         Format::GitHub => github::render_delta_github(report, threshold, out),
         Format::Markdown => markdown::render_delta_markdown(report, threshold, links, out),
         Format::PrComment => pr_comment::render_delta_pr_comment(report, threshold, links, out),
+        // SARIF describes the *current* set of findings, not deltas. The
+        // upstream consumers (GitHub Code Scanning, VS Code) don't model
+        // baseline diffs, so combining `--baseline` with `--format sarif`
+        // is rejected rather than silently emitting an unrelated shape.
+        Format::Sarif => bail!(
+            "--format sarif is incompatible with --baseline; use --format json for delta output"
+        ),
     }
 }
 

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -1,0 +1,317 @@
+//! `--format sarif` — SARIF 2.1.0 output for GitHub Code Scanning, VS Code,
+//! and the broader static-analysis ecosystem.
+//!
+//! Only crappy functions (entries above the threshold) appear as `results`.
+//! The wrapping `runs` / `tool` / `driver` blocks always emit, so an empty
+//! result set still produces a valid SARIF document upload-able to GitHub.
+
+use crate::merge::CrapEntry;
+use crate::score::Severity;
+use anyhow::Result;
+use serde::Serialize;
+use std::io::Write;
+use std::path::Path;
+
+const DRIVER_NAME: &str = "cargo-crap";
+const DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const DRIVER_INFO_URI: &str = "https://github.com/minikin/cargo-crap";
+const RULE_ID: &str = "crap/high-score";
+const SARIF_VERSION: &str = "2.1.0";
+const SARIF_SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+
+#[derive(Serialize)]
+struct SarifLog {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+struct SarifDriver {
+    name: &'static str,
+    version: &'static str,
+    #[serde(rename = "informationUri")]
+    information_uri: &'static str,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Serialize)]
+struct SarifRule {
+    id: &'static str,
+    #[serde(rename = "shortDescription")]
+    short_description: SarifText,
+    #[serde(rename = "fullDescription")]
+    full_description: SarifText,
+    #[serde(rename = "defaultConfiguration")]
+    default_configuration: SarifLevel,
+    #[serde(rename = "helpUri")]
+    help_uri: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifText {
+    text: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifLevel {
+    level: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: &'static str,
+    level: &'static str,
+    message: SarifMessage,
+    locations: Vec<SarifLocation>,
+}
+
+#[derive(Serialize)]
+struct SarifMessage {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifactLocation,
+    region: SarifRegion,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: usize,
+}
+
+pub(crate) fn render_sarif(
+    entries: &[CrapEntry],
+    threshold: f64,
+    out: &mut dyn Write,
+) -> Result<()> {
+    let results: Vec<SarifResult> = entries
+        .iter()
+        .filter(|e| Severity::classify(e.crap, threshold) == Severity::Crappy)
+        .map(build_result)
+        .collect();
+
+    let log = SarifLog {
+        schema: SARIF_SCHEMA_URL,
+        version: SARIF_VERSION,
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: build_driver(),
+            },
+            results,
+        }],
+    };
+
+    serde_json::to_writer_pretty(&mut *out, &log)?;
+    out.write_all(b"\n")?;
+    Ok(())
+}
+
+fn build_driver() -> SarifDriver {
+    SarifDriver {
+        name: DRIVER_NAME,
+        version: DRIVER_VERSION,
+        information_uri: DRIVER_INFO_URI,
+        rules: vec![SarifRule {
+            id: RULE_ID,
+            short_description: SarifText {
+                text: "CRAP score above threshold",
+            },
+            full_description: SarifText {
+                text: "The Change Risk Anti-Patterns (CRAP) score combines cyclomatic \
+                       complexity and test coverage. Functions whose CRAP exceeds the \
+                       configured threshold are flagged for refactoring or test additions.",
+            },
+            default_configuration: SarifLevel { level: "warning" },
+            help_uri: DRIVER_INFO_URI,
+        }],
+    }
+}
+
+fn build_result(entry: &CrapEntry) -> SarifResult {
+    SarifResult {
+        rule_id: RULE_ID,
+        level: "warning",
+        message: SarifMessage {
+            text: format_message(entry),
+        },
+        locations: vec![SarifLocation {
+            physical_location: SarifPhysicalLocation {
+                artifact_location: SarifArtifactLocation {
+                    uri: normalize_path(&entry.file),
+                },
+                region: SarifRegion {
+                    start_line: entry.line,
+                },
+            },
+        }],
+    }
+}
+
+fn format_message(entry: &CrapEntry) -> String {
+    let coverage = entry
+        .coverage
+        .map_or_else(|| "n/a".to_string(), |c| format!("{c:.1}%"));
+    format!(
+        "Function `{}` has CRAP score {:.1} (cyclomatic complexity {}, coverage {})",
+        entry.function, entry.crap, entry.cyclomatic as u64, coverage,
+    )
+}
+
+/// Convert a path to a forward-slash URI string. SARIF's `artifactLocation.uri`
+/// must use `/` regardless of host platform — Windows backslashes become `/`.
+fn normalize_path(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::sample;
+    use super::super::{Format, render};
+    use super::*;
+
+    fn render_to_value(threshold: f64) -> serde_json::Value {
+        let mut buf = Vec::new();
+        render(&sample(), threshold, Format::Sarif, None, &mut buf).unwrap();
+        serde_json::from_slice(&buf).expect("output must be valid JSON")
+    }
+
+    #[test]
+    fn sarif_output_has_schema_and_version_fields() {
+        let v = render_to_value(30.0);
+        assert_eq!(v["$schema"].as_str(), Some(SARIF_SCHEMA_URL));
+        assert_eq!(v["version"].as_str(), Some(SARIF_VERSION));
+    }
+
+    #[test]
+    fn sarif_output_has_one_run_with_a_driver() {
+        let v = render_to_value(30.0);
+        let runs = v["runs"].as_array().expect("runs array");
+        assert_eq!(runs.len(), 1);
+        let driver = &runs[0]["tool"]["driver"];
+        assert_eq!(driver["name"].as_str(), Some(DRIVER_NAME));
+        assert_eq!(driver["version"].as_str(), Some(DRIVER_VERSION));
+        assert_eq!(driver["informationUri"].as_str(), Some(DRIVER_INFO_URI));
+    }
+
+    #[test]
+    fn crappy_function_appears_as_a_result() {
+        let v = render_to_value(30.0);
+        let results = v["runs"][0]["results"].as_array().expect("results array");
+        // sample() has one entry above the default threshold of 30 — `crappy`
+        // (CRAP 110.0) — and one clean entry (CRAP 1.0).
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert_eq!(result["ruleId"].as_str(), Some(RULE_ID));
+        assert_eq!(result["level"].as_str(), Some("warning"));
+        let location = &result["locations"][0]["physicalLocation"];
+        assert_eq!(
+            location["artifactLocation"]["uri"].as_str(),
+            Some("a.rs"),
+            "uri must be the entry's file"
+        );
+        assert_eq!(
+            location["region"]["startLine"].as_u64(),
+            Some(10),
+            "startLine must match the entry's line"
+        );
+        let message = result["message"]["text"]
+            .as_str()
+            .expect("message.text must be a string");
+        assert!(
+            message.contains("110"),
+            "message must mention the CRAP score, got: {message}"
+        );
+        assert!(
+            message.contains("crappy"),
+            "message must mention the function name, got: {message}"
+        );
+    }
+
+    #[test]
+    fn clean_function_does_not_appear_as_a_result() {
+        let v = render_to_value(30.0);
+        let results = v["runs"][0]["results"].as_array().expect("results array");
+        // No result should reference the clean function.
+        for r in results {
+            let msg = r["message"]["text"].as_str().unwrap_or("");
+            assert!(!msg.contains("clean"), "clean function must not appear");
+        }
+    }
+
+    #[test]
+    fn empty_entries_produce_valid_sarif_with_empty_results() {
+        let mut buf = Vec::new();
+        render(&[], 30.0, Format::Sarif, None, &mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
+        assert_eq!(v["version"].as_str(), Some(SARIF_VERSION));
+        let results = v["runs"][0]["results"]
+            .as_array()
+            .expect("results array must exist even when empty");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn high_threshold_filters_all_entries() {
+        // sample()'s worst entry is 110.0 — a threshold of 200 leaves nothing.
+        let v = render_to_value(200.0);
+        let results = v["runs"][0]["results"].as_array().expect("results array");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn windows_style_paths_are_normalized_to_forward_slashes() {
+        assert_eq!(normalize_path(Path::new("src\\foo.rs")), "src/foo.rs");
+        assert_eq!(
+            normalize_path(Path::new("a\\b\\c.rs")),
+            "a/b/c.rs",
+            "every backslash must be replaced",
+        );
+    }
+
+    #[test]
+    fn delta_mode_with_sarif_format_returns_an_error() {
+        use super::super::render_delta;
+        use crate::delta::DeltaReport;
+        let report = DeltaReport {
+            entries: Vec::new(),
+            removed: Vec::new(),
+        };
+        let mut buf = Vec::new();
+        let err = render_delta(&report, 30.0, Format::Sarif, None, &mut buf)
+            .expect_err("delta + sarif must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--format sarif") && msg.contains("--baseline"),
+            "error must explain the incompatibility, got: {msg}"
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -586,6 +586,144 @@ fn allow_invalid_glob_exits_with_error() {
         .stderr(predicate::str::contains("invalid allow pattern"));
 }
 
+// --- --format sarif (spec 07) ---
+
+#[test]
+fn sarif_output_is_valid_json_with_required_envelope() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--format")
+        .arg("sarif")
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+
+    assert_eq!(
+        v["version"].as_str(),
+        Some("2.1.0"),
+        "SARIF version field must be \"2.1.0\""
+    );
+    assert!(
+        v["$schema"]
+            .as_str()
+            .is_some_and(|s| s.contains("sarif-2.1.0")),
+        "$schema must reference SARIF 2.1.0, got: {:?}",
+        v["$schema"]
+    );
+    let runs = v["runs"].as_array().expect("runs must be an array");
+    assert_eq!(runs.len(), 1, "expected exactly one run");
+    let driver = &runs[0]["tool"]["driver"];
+    assert_eq!(driver["name"].as_str(), Some("cargo-crap"));
+}
+
+#[test]
+fn sarif_output_contains_a_result_for_a_crappy_fixture_function() {
+    // Without --lcov, `crappy` is treated as 0% covered and lands well
+    // above the default threshold of 30. It must appear as a SARIF result
+    // pointing at lib.rs.
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--format")
+        .arg("sarif")
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let results = v["runs"][0]["results"]
+        .as_array()
+        .expect("results must be an array");
+    let crappy = results
+        .iter()
+        .find(|r| {
+            r["message"]["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("crappy"))
+        })
+        .expect("expected one result for `crappy`");
+    assert_eq!(crappy["level"].as_str(), Some("warning"));
+    let region = &crappy["locations"][0]["physicalLocation"]["region"];
+    assert!(
+        region["startLine"].as_u64().unwrap_or(0) > 0,
+        "startLine must be a positive line number"
+    );
+    let uri = crappy["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        .as_str()
+        .expect("uri must be a string");
+    assert!(
+        uri.ends_with("lib.rs"),
+        "result must point at lib.rs, got: {uri}"
+    );
+}
+
+#[test]
+fn sarif_output_with_high_threshold_has_empty_results() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--threshold")
+        .arg("10000")
+        .arg("--format")
+        .arg("sarif")
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["version"].as_str(), Some("2.1.0"));
+    let results = v["runs"][0]["results"]
+        .as_array()
+        .expect("results array must exist even when empty");
+    assert!(
+        results.is_empty(),
+        "no entry should exceed a 10000 threshold, got: {results:?}"
+    );
+}
+
+#[test]
+fn sarif_with_fail_above_exits_one_when_threshold_exceeded() {
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--format")
+        .arg("sarif")
+        .arg("--fail-above")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn sarif_with_baseline_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline = dir.path().join("baseline.json");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&baseline)
+        .assert()
+        .success();
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("sarif")
+        .arg("--baseline")
+        .arg(&baseline)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--baseline"));
+}
+
 // --- --output ---
 
 #[test]


### PR DESCRIPTION
## Summary

- New `--format sarif` emits SARIF 2.1.0 JSON suitable for upload to GitHub Code Scanning (`gh code-scanning upload-results`), VS Code, and the broader static-analysis ecosystem.
- Each crappy function becomes one warning-level result with a physical location at its start line. Below-threshold functions are not included.
- Empty result sets still produce a valid SARIF document (the run/tool/driver blocks always emit).
- `--baseline` is rejected with `--format sarif` — SARIF describes findings, not deltas. Use `--format json` for delta output.
- `--summary` keeps existing semantics (format-independent summary text).

## Test plan

- [x] Unit tests in `src/report/sarif.rs` cover: `$schema` + `version`, single-run/driver shape, crappy function appears as result, clean function does not, empty entries → valid empty results, high threshold filters all, Windows path normalization, delta+sarif rejection.
- [x] CLI integration tests in `tests/cli.rs`: valid JSON envelope, result for the `crappy` fixture function (with line number + lib.rs uri), high-threshold empty results, `--fail-above` exits 1, `--baseline` is rejected with stderr mentioning `--baseline`.
- [x] `just dev-mutants-diff` passed on `src/main.rs` + `src/report.rs` (50/60 caught, 10 unviable).
- [x] `cargo mutants --file src/report/sarif.rs` separately: 6/8 caught, 2 unviable. (`dev-mutants-diff`'s `src/*.rs` glob doesn't reach `src/report/`, so the new file was checked manually.)
- [x] All 254 tests pass.

## Notes / judgment calls

- **Hand-rolled SARIF structs** rather than the `serde_sarif` crate. The subset we emit is small (log → run → tool/driver/rules + results → physicalLocation) and maintaining a tiny purpose-built model is lighter than pulling in a crate that pre-defines the entire SARIF surface.
- **`--baseline` + `--format sarif`** returns an explicit error rather than silently emitting current findings. SARIF consumers (GitHub Code Scanning, VS Code) don't model baseline diffs, so silent fall-through would be misleading.
- **Path normalization**: `artifactLocation.uri` always uses `/` (Windows backslashes are converted). Paths flow through unchanged otherwise — no canonicalization.
- **Driver**: `name = cargo-crap`, `version = env!("CARGO_PKG_VERSION")`, `informationUri` + rule `helpUri` both point at the repo. Single rule `crap/high-score` with default level `warning`.

Closes spec 07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)