### PR TITLE
chore(justfile): include src subdirectories in dev-mutants-diff pathspec

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,18 +38,20 @@ mutants FILE:
 dev-full: dev
     cargo mutants
 
-# Mutation tests only on files changed vs HEAD (uncommitted) or last commit
+# Mutation tests only on files changed vs HEAD (uncommitted) or last commit.
+# The 'src/**/*.rs' pathspec catches files inside subdirectories
+# (src/report/sarif.rs, etc.) — a plain 'src/*.rs' would skip them.
 dev-mutants-diff: dev
     #!/usr/bin/env bash
     set -euo pipefail
     # First: uncommitted changes (staged + unstaged)
-    files=$(git diff --name-only HEAD -- 'src/*.rs' 2>/dev/null || true)
+    files=$(git diff --name-only HEAD -- 'src/**/*.rs' 'src/*.rs' 2>/dev/null || true)
     # Fallback: files changed in the last commit
     if [ -z "$files" ]; then
-        files=$(git diff --name-only HEAD~1 HEAD -- 'src/*.rs' 2>/dev/null || true)
+        files=$(git diff --name-only HEAD~1 HEAD -- 'src/**/*.rs' 'src/*.rs' 2>/dev/null || true)
     fi
     if [ -z "$files" ]; then
-        echo "No changed src/*.rs files — running all mutants"
+        echo "No changed src/**/*.rs files — running all mutants"
         cargo mutants
     else
         echo "Running mutants on: $files"


### PR DESCRIPTION
## Summary

The `dev-mutants-diff` recipe used `git diff --name-only HEAD -- 'src/*.rs'`, which only matches `.rs` files directly under `src/`. New files in subdirectories — `src/report/sarif.rs`, anything under `src/report/`, `src/score.rs`, etc. — were silently skipped by the diff filter.

Add `src/**/*.rs` to the pathspec (kept `src/*.rs` alongside it as belt-and-braces). Verified locally that all three changed files on the spec 07 branch (`src/main.rs`, `src/report.rs`, `src/report/sarif.rs`) are now picked up.

## Test plan

- [x] `git diff --name-only HEAD -- 'src/**/*.rs' 'src/*.rs'` returns the full set of changed `.rs` files when subdir files exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)