### PR TITLE
docs(specs): add specs 14 and 15

### DIFF
--- a/specs/14-default-target-exclusions.md
+++ b/specs/14-default-target-exclusions.md
@@ -1,0 +1,92 @@
+# Spec 14 — Default exclusion of tests, benches, and examples
+
+**Status:** Proposed
+**Effort:** Small
+**Module:** `src/complexity.rs` (`analyze_tree`), `src/main.rs`, `src/config.rs`
+
+## Context
+
+`tests/`, `benches/`, and `examples/` are standard Cargo target directories
+that rarely benefit from CRAP analysis: integration tests exist to cover
+production code, not to be covered themselves; benchmarks and examples are
+scaffolding. Including them inflates the function count and creates noise in
+CI gates.
+
+`#[cfg(test)]` inline modules are already excluded during the AST walk.
+This spec extends that to the three standard directory trees.
+
+The default is to exclude. `--include-tests` restores the old behaviour for
+teams that do want to audit their test code.
+
+---
+
+## Acceptance Tests
+
+### Scenario: tests/ is excluded by default
+
+```
+Given a Rust project with functions in src/lib.rs and tests/integration.rs
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from tests/integration.rs do not appear in the output
+And   functions from src/lib.rs are still shown
+```
+
+### Scenario: benches/ is excluded by default
+
+```
+Given a Rust project with functions in src/lib.rs and benches/bench.rs
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from benches/bench.rs do not appear in the output
+And   functions from src/lib.rs are still shown
+```
+
+### Scenario: examples/ is excluded by default
+
+```
+Given a Rust project with functions in src/lib.rs and examples/demo.rs
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from examples/demo.rs do not appear in the output
+And   functions from src/lib.rs are still shown
+```
+
+### Scenario: --include-tests restores all three directories
+
+```
+Given a Rust project with functions in src/lib.rs, tests/, benches/, and examples/
+When  I run `cargo crap --lcov lcov.info --include-tests`
+Then  functions from all directories appear in the output
+```
+
+### Scenario: --include-tests configurable in .cargo-crap.toml
+
+```
+Given a .cargo-crap.toml containing:
+      include_tests = true
+When  I run `cargo crap --lcov lcov.info` without --include-tests
+Then  functions from tests/, benches/, and examples/ appear in the output
+```
+
+### Scenario: CLI --include-tests overrides config file default
+
+```
+Given a .cargo-crap.toml with no include_tests entry (defaults to false)
+When  I run `cargo crap --lcov lcov.info --include-tests`
+Then  functions from tests/, benches/, and examples/ appear in the output
+```
+
+### Scenario: --exclude still works alongside default exclusions
+
+```
+Given a Rust project
+When  I run `cargo crap --lcov lcov.info --exclude 'src/generated/**'`
+Then  src/generated/ is excluded
+And   tests/, benches/, and examples/ are also excluded (default behaviour)
+```
+
+### Scenario: default exclusions apply in workspace mode
+
+```
+Given a workspace with crates that each have tests/, benches/, and examples/ directories
+When  I run `cargo crap --workspace --lcov lcov.info`
+Then  no functions from any tests/, benches/, or examples/ directory appear in the output
+```

--- a/specs/15-shields-badge.md
+++ b/specs/15-shields-badge.md
@@ -1,0 +1,170 @@
+# Spec 15 — Shields.io endpoint badge
+
+**Status:** Proposed
+**Effort:** Small
+**Module:** `src/report.rs`, `src/report/shields.rs`, `src/main.rs`
+
+## Context
+
+A README badge gives instant visibility into codebase quality without opening
+CI logs. Shields.io supports
+[custom endpoint badges](https://shields.io/badges/endpoint-badge): you
+generate a small JSON file, serve it at a stable URL (e.g. via GitHub Pages or
+a raw GitHub blob), and embed it in the README as a normal badge image.
+
+`--format shields` produces that JSON file. The badge communicates how many
+functions currently exceed the configured CRAP threshold.
+
+Embed example:
+
+```markdown
+![CRAP](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/owner/repo/main/crap-badge.json)
+```
+
+---
+
+## Output schema
+
+The output is a single JSON object following the
+[Shields.io endpoint schema v1](https://shields.io/endpoint):
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "CRAP",
+  "message": "<message>",
+  "color": "<color>"
+}
+```
+
+### Message and color rules
+
+| Functions above threshold | `message`      | `color`       |
+|---------------------------|----------------|---------------|
+| 0                         | `passing`      | `brightgreen` |
+| 1 – 5                     | `N crappy`     | `yellow`      |
+| 6+                        | `N crappy`     | `red`         |
+
+`N` is the count of functions whose CRAP score exceeds `--threshold`.
+
+---
+
+## Acceptance Tests
+
+### Scenario: All functions below threshold produces a passing badge
+
+```
+Given a project where no function exceeds the threshold
+When  I run `cargo crap --format shields --output crap-badge.json`
+Then  crap-badge.json contains valid JSON
+And   "schemaVersion" is 1
+And   "label" is "CRAP"
+And   "message" is "passing"
+And   "color" is "brightgreen"
+```
+
+### Scenario: A few functions above threshold produces a yellow badge
+
+```
+Given a project where 3 functions exceed the threshold
+When  I run `cargo crap --format shields --output crap-badge.json`
+Then  "message" is "3 crappy"
+And   "color" is "yellow"
+```
+
+### Scenario: Many functions above threshold produces a red badge
+
+```
+Given a project where 8 functions exceed the threshold
+When  I run `cargo crap --format shields --output crap-badge.json`
+Then  "message" is "8 crappy"
+And   "color" is "red"
+```
+
+### Scenario: --threshold controls the count
+
+```
+Given a project with functions at various CRAP scores
+When  I run `cargo crap --format shields --threshold 50`
+Then  only functions with CRAP > 50 are counted toward the badge message
+```
+
+### Scenario: Output written to --output file
+
+```
+Given I run `cargo crap --format shields --output crap-badge.json`
+When  I read crap-badge.json
+Then  it contains the Shields.io endpoint JSON
+And   stdout is empty
+```
+
+### Scenario: --format shields ignores --baseline
+
+```
+Given a baseline file exists
+When  I run `cargo crap --format shields --baseline baseline.json`
+Then  the badge reflects the absolute current scores only
+And   no delta information is included in the output
+```
+
+### Scenario: Workspace mode aggregates all crates
+
+```
+Given a Cargo workspace with multiple crates
+When  I run `cargo crap --workspace --format shields`
+Then  the badge count reflects functions above threshold across all crates combined
+```
+
+---
+
+## Implementation Notes
+
+### New format variant
+
+Add `shields` to the `--format` clap value enum alongside the existing variants.
+
+### Renderer (`src/report/shields.rs`)
+
+```rust
+pub fn render_shields(entries: &[CrapEntry], threshold: f64, out: &mut dyn Write) -> Result<()>
+```
+
+Count entries where `entry.crap > threshold`, then emit:
+
+```rust
+let (message, color) = match count {
+    0 => ("passing".into(), "brightgreen"),
+    1..=5 => (format!("{count} crappy"), "yellow"),
+    _ => (format!("{count} crappy"), "red"),
+};
+```
+
+The output is a single `serde_json` object — no versioned envelope, no array.
+
+### No delta variant
+
+`--format shields` does not support delta mode. If `--baseline` is supplied
+alongside `--format shields`, the baseline flag is silently ignored and the
+badge reflects absolute scores only.
+
+### Suggested CI usage
+
+```yaml
+- name: Generate CRAP badge
+  run: |
+    cargo run --release -- \
+      --lcov lcov.info \
+      --workspace \
+      --exclude 'tests/fixtures/**' \
+      --threshold 30 \
+      --format shields \
+      --output crap-badge.json
+
+- name: Commit badge
+  run: |
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git add crap-badge.json
+    git diff --cached --quiet || git commit -m "chore: update CRAP badge"
+    git push
+```


### PR DESCRIPTION
Add Spec 14: default exclusion of tests/, benches/, and examples/ with an
--include-tests flag to opt back in.

Add Spec 15: --format shields output for a Shields.io endpoint badge,
communicating how many functions exceed the configured threshold.