### PR TITLE
docs(specs): generalize spec 14 to default-exclude globs, add spec 18

### DIFF
--- a/specs/14-default-target-exclusions.md
+++ b/specs/14-default-target-exclusions.md
@@ -2,21 +2,62 @@
 
 **Status:** Proposed
 **Effort:** Small
-**Module:** `src/complexity.rs` (`analyze_tree`), `src/main.rs`, `src/config.rs`
+**Module:** `src/main.rs` (effective-exclude assembly), `src/config.rs`
 
 ## Context
 
 `tests/`, `benches/`, and `examples/` are standard Cargo target directories
 that rarely benefit from CRAP analysis: integration tests exist to cover
 production code, not to be covered themselves; benchmarks and examples are
-scaffolding. Including them inflates the function count and creates noise in
-CI gates.
+scaffolding that is not even executed during a coverage run. Including them
+inflates the function count and creates noise in CI gates.
 
 `#[cfg(test)]` inline modules are already excluded during the AST walk.
 This spec extends that to the three standard directory trees.
 
-The default is to exclude. `--include-tests` restores the old behaviour for
-teams that do want to audit their test code.
+### Mechanism: default excludes are ordinary exclude globs
+
+No new matching machinery is introduced. The tool ships a built-in list of
+default exclude globs:
+
+```
+tests/**
+benches/**
+examples/**
+```
+
+which is prepended to the user's exclude patterns during effective-exclude
+assembly in `src/main.rs`. `analyze_tree` is unchanged — the defaults flow
+through the same glob pipeline as `--exclude`.
+
+Because exclude globs are matched relative to each analyzed root (each
+workspace member's directory in `--workspace` mode), the defaults only match
+the *top-level* target directories of each crate — mirroring Cargo's own
+auto-discovery. A module directory that happens to be named `tests/` deeper
+in the tree (e.g. `src/tests/helpers.rs`) is not affected. Likewise,
+explicitly analyzing a path inside a target directory
+(`cargo crap tests/regression --lcov ...`) works: the globs are relative to
+that root, so nothing matches.
+
+### Precedence
+
+1. The built-in default list is `["tests/**", "benches/**", "examples/**"]`.
+2. `default_excludes = [...]` in `.cargo-crap.toml`, if present, **replaces**
+   the built-in list entirely. `[]` disables the defaults; a subset
+   re-includes some directories; a superset extends the defaults.
+3. `--no-default-excludes` on the CLI sets the effective default list to
+   empty, overriding both the built-in list and any config replacement.
+4. The existing `exclude` config key and `--exclude` CLI flag **append** to
+   the effective default list. They never replace it.
+
+### Non-goals
+
+- No Cargo manifest awareness: custom target paths (`[[test]] path = ...`,
+  `autotests = false`) are not consulted. This is a directory-name heuristic
+  on the standard layout, not a `cargo metadata`-driven feature.
+- No CLI flag to *set* the default list (`--default-excludes <globs>`).
+  Config replacement plus `--no-default-excludes` covers the known cases;
+  a setter flag can be added later without breaking anything.
 
 ---
 
@@ -49,32 +90,62 @@ Then  functions from examples/demo.rs do not appear in the output
 And   functions from src/lib.rs are still shown
 ```
 
-### Scenario: --include-tests restores all three directories
+### Scenario: directories named tests/ deeper in the tree are not excluded
+
+```
+Given a Rust project with functions in src/tests/helpers.rs
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from src/tests/helpers.rs still appear in the output
+```
+
+### Scenario: --no-default-excludes restores all three directories
 
 ```
 Given a Rust project with functions in src/lib.rs, tests/, benches/, and examples/
-When  I run `cargo crap --lcov lcov.info --include-tests`
+When  I run `cargo crap --lcov lcov.info --no-default-excludes`
 Then  functions from all directories appear in the output
 ```
 
-### Scenario: --include-tests configurable in .cargo-crap.toml
+### Scenario: default_excludes = [] in config disables the defaults
 
 ```
 Given a .cargo-crap.toml containing:
-      include_tests = true
-When  I run `cargo crap --lcov lcov.info` without --include-tests
+      default_excludes = []
+When  I run `cargo crap --lcov lcov.info` without --no-default-excludes
 Then  functions from tests/, benches/, and examples/ appear in the output
 ```
 
-### Scenario: CLI --include-tests overrides config file default
+### Scenario: default_excludes subset re-includes only some directories
 
 ```
-Given a .cargo-crap.toml with no include_tests entry (defaults to false)
-When  I run `cargo crap --lcov lcov.info --include-tests`
+Given a .cargo-crap.toml containing:
+      default_excludes = ["benches/**", "examples/**"]
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from tests/ appear in the output
+And   functions from benches/ and examples/ do not appear in the output
+```
+
+### Scenario: default_excludes superset extends the defaults
+
+```
+Given a .cargo-crap.toml containing:
+      default_excludes = ["tests/**", "benches/**", "examples/**", "fuzz/**"]
+And   a Rust project with functions in src/lib.rs and fuzz/fuzz_targets/run.rs
+When  I run `cargo crap --lcov lcov.info`
+Then  functions from fuzz/fuzz_targets/run.rs do not appear in the output
+And   functions from src/lib.rs are still shown
+```
+
+### Scenario: CLI --no-default-excludes overrides config default_excludes
+
+```
+Given a .cargo-crap.toml containing:
+      default_excludes = ["tests/**"]
+When  I run `cargo crap --lcov lcov.info --no-default-excludes`
 Then  functions from tests/, benches/, and examples/ appear in the output
 ```
 
-### Scenario: --exclude still works alongside default exclusions
+### Scenario: --exclude appends to the defaults, never replaces them
 
 ```
 Given a Rust project
@@ -83,10 +154,19 @@ Then  src/generated/ is excluded
 And   tests/, benches/, and examples/ are also excluded (default behaviour)
 ```
 
-### Scenario: default exclusions apply in workspace mode
+### Scenario: explicitly analyzing a path inside tests/ still works
+
+```
+Given a Rust project with functions in tests/regression/big_test.rs
+When  I run `cargo crap tests/regression --lcov lcov.info`
+Then  functions from tests/regression/big_test.rs appear in the output
+```
+
+### Scenario: default exclusions apply per-crate in workspace mode
 
 ```
 Given a workspace with crates that each have tests/, benches/, and examples/ directories
 When  I run `cargo crap --workspace --lcov lcov.info`
-Then  no functions from any tests/, benches/, or examples/ directory appear in the output
+Then  no functions from any crate's tests/, benches/, or examples/ directory appear in the output
+And   functions from each crate's src/ are still shown
 ```

--- a/specs/16-baseline-filtering-before-delta.md
+++ b/specs/16-baseline-filtering-before-delta.md
@@ -1,0 +1,175 @@
+# Spec 16 — Baseline entries are filtered through current-run exclusions before delta
+
+**Status:** Proposed
+**Effort:** Small
+**Module:** `src/main.rs` (`do_render`), `src/delta.rs` (filter helper)
+
+## Context
+
+`compute_delta` treats every baseline function with no current-side pair as
+`removed`. That is correct when the code was deleted — and wrong when the
+current run simply *stopped analyzing* the file. The delta engine cannot
+tell the difference today, so the two cases render identically.
+
+Spec 14 makes this acute. Baselines written before the default exclusions
+contain every function in `tests/`, `benches/`, and `examples/`. The first
+delta run after upgrading dumps all of them into `removed` at once — a wall
+of one-time noise in PR comments, the same misleading-breakdown problem that
+motivated spec 13 ("60 new + 59 removed" for a pure refactor). The same
+thing happens, at smaller scale, whenever a user adds an `--exclude` or an
+`--allow` pattern between the baseline run and the current run.
+
+It is worse than cosmetic. Unpaired baseline entries participate in the
+spec-13 pass-2 name matcher: a baseline `tests/common.rs:setup_fixture`
+whose name is unique on both sides can pair with an unrelated brand-new
+`src/` function of the same name and report a phantom move
+(`Moved`, `previous_file = tests/common.rs`) — or worse, a phantom
+`Regressed` if the scores differ.
+
+### Rule
+
+Before `compute_delta` runs, drop every baseline entry that the current
+run's own *identity-based* filters would have dropped:
+
+1. the effective default-exclude list (built-in / `default_excludes` /
+   `--no-default-excludes`, per spec 14 precedence),
+2. exclude globs (`exclude` config key + `--exclude`),
+3. `--allow` / `allow` patterns, both path-shaped and name-shaped, applied
+   the same way `apply_filters` applies them to current entries.
+
+A filtered baseline entry simply does not exist for delta purposes: it
+appears in no bucket (`removed` included), no breakdown count, and is not a
+pass-2 pairing candidate.
+
+The filter is unconditional — no flag, no config key. The worst case is a
+genuinely deleted function inside an excluded directory not being reported
+as removed, which is consistent: the tool does not report on excluded paths
+in any other context either.
+
+### Non-goals
+
+- **No `--min` / `--top` symmetry.** Those filters select by score and rank,
+  not identity. Applying them to the baseline would mask genuine changes
+  (e.g. a function that improved from CRAP 50 to 2 must not have its
+  baseline entry dropped by `--min 5`). The asymmetry noise they can cause
+  in `removed` is pre-existing and accepted; it is out of scope here.
+- No change to `compute_delta`'s matching algorithm itself (spec 13 stands).
+
+---
+
+## Acceptance Tests
+
+### Scenario: pre-spec-14 baseline does not flood `removed`
+
+```
+Given a baseline JSON written before default exclusions existed, containing
+      entries from src/lib.rs and tests/integration.rs
+When  I run `cargo crap --lcov lcov.info --baseline old.json`
+Then  no tests/integration.rs entry appears in `removed`
+And   the breakdown's removed count includes only genuinely deleted
+      src/ functions
+```
+
+### Scenario: entries excluded by --exclude are filtered from the baseline
+
+```
+Given a baseline containing entries from src/generated/api.rs
+When  I run `cargo crap --lcov lcov.info --baseline old.json
+      --exclude 'src/generated/**'`
+Then  no src/generated/api.rs entry appears in `removed`
+```
+
+### Scenario: genuinely deleted functions are still reported as removed
+
+```
+Given a baseline containing src/lib.rs:old_helper
+And   a current run in which src/lib.rs no longer defines old_helper
+When  I run `cargo crap --lcov lcov.info --baseline old.json`
+Then  old_helper appears in `removed` (unchanged behaviour)
+```
+
+### Scenario: filtered baseline entries cannot produce phantom moves
+
+```
+Given a baseline containing tests/common.rs:setup_fixture
+And   a current run where tests/ is excluded by default
+And   a brand-new function setup_fixture in src/lib.rs
+And   no other function named setup_fixture on either side
+When  compute_delta runs
+Then  the src/lib.rs:setup_fixture entry has status `New`
+And   its `previous_file` is None (no pass-2 pairing with the filtered entry)
+And   `removed` is empty
+```
+
+### Scenario: --no-default-excludes restores full-baseline comparison
+
+```
+Given a baseline containing entries from tests/integration.rs
+When  I run `cargo crap --lcov lcov.info --baseline old.json
+      --no-default-excludes`
+Then  tests/integration.rs entries are compared normally
+      (the filter uses the *effective* exclusion set, which is empty here)
+```
+
+### Scenario: name-shaped --allow patterns filter the baseline too
+
+```
+Given a baseline containing src/codegen.rs:generated_parse_v1
+When  I run `cargo crap --lcov lcov.info --baseline old.json
+      --allow 'generated_*'`
+Then  generated_parse_v1 does not appear in `removed`
+```
+
+### Scenario: path-shaped --allow patterns filter the baseline too
+
+```
+Given a baseline containing entries from src/generated/api.rs
+When  I run `cargo crap --lcov lcov.info --baseline old.json
+      --allow 'src/generated/**'`
+Then  no src/generated/api.rs entry appears in `removed`
+```
+
+### Scenario: Windows-written baselines match forward-slash globs
+
+```
+Given a baseline written on Windows containing the file
+      `tests\integration.rs`
+When  I run `cargo crap --lcov lcov.info --baseline old.json`
+      with the default exclusions active
+Then  the entry is filtered (path separators are normalized before glob
+      matching, as in delta's path_key)
+```
+
+### Scenario: workspace mode filters baseline entries per member root
+
+```
+Given a workspace baseline containing entries from
+      crates/foo/tests/it.rs and crates/foo/src/lib.rs
+When  I run `cargo crap --workspace --lcov lcov.info --baseline old.json`
+Then  crates/foo/tests/it.rs entries are filtered (the glob `tests/**`
+      applies relative to each member's root, mirroring analyze_tree)
+And   crates/foo/src/lib.rs entries are compared normally
+```
+
+---
+
+## Implementation Notes
+
+- **Where:** in `do_render` (`src/main.rs`), between `load_baseline` and
+  `compute_delta`. The effective exclude list and allow patterns must be
+  threaded into `do_render`; today it only receives render options.
+- **Helper:** a pure `filter_baseline(entries, exclude_set, allow_sets)`
+  in `src/delta.rs` keeps the logic testable next to the delta tests.
+- **Glob reuse:** build the sets with the existing `build_exclude_set` /
+  `build_allow_set` / `build_path_allow_set` machinery — no new matching
+  semantics.
+- **Path normalization:** convert `\` to `/` before matching (same
+  normalization as `path_key`) so cross-platform baselines behave.
+- **Workspace roots:** exclude globs are root-relative (spec 14). For each
+  baseline path, strip the longest matching workspace-member directory
+  prefix before matching — the same longest-match rule
+  `assign_crate_names` already uses — so `crates/foo/tests/it.rs` is tested
+  as `tests/it.rs` against `tests/**`. In single-crate mode the analyzed
+  root is the prefix.
+- **Counts:** filtered entries must not be counted anywhere — not in
+  `removed`, not in any renderer breakdown, not in `regression_count`.

--- a/specs/18-baseline-filtering-before-delta.md
+++ b/specs/18-baseline-filtering-before-delta.md
@@ -1,4 +1,4 @@
-# Spec 16 — Baseline entries are filtered through current-run exclusions before delta
+# Spec 18 — Baseline entries are filtered through current-run exclusions before delta
 
 **Status:** Proposed
 **Effort:** Small


### PR DESCRIPTION
## Summary

### Spec 14 — rewritten around a generic mechanism
- Default exclusion of `tests/`, `benches/`, `examples/` is now modeled as a built-in list of ordinary exclude globs prepended during effective-exclude assembly in `src/main.rs` — `analyze_tree` is untouched.
- `--no-default-excludes` (CLI) empties the effective default list; `default_excludes = [...]` (config) replaces it wholesale (`[]` disables, subset re-includes, superset extends e.g. with `fuzz/**`). The existing `exclude`/`--exclude` always append.
- Replaces the previous `--include-tests` boolean design, whose name promised less than it did.
- New scenarios pin root-relative matching (`src/tests/helpers.rs` is **not** excluded), config subset/superset, CLI-over-config precedence, the positional-path escape hatch, and per-crate behavior in workspace mode.
- Non-goals recorded: no Cargo manifest awareness (`[[test]] path`, `autotests = false`), no `--default-excludes` setter flag yet.

### Spec 18 — new: baseline filtering before delta
- Before `compute_delta`, baseline entries are dropped when the current run's identity-based filters (effective default excludes, `--exclude`, `--allow`) would have dropped them.
- Fixes the post-spec-14 upgrade wall of `removed` noise, and the pre-existing `--allow` asymmetry (allowed baseline functions show as removed today).
- Also prevents phantom spec-13 pass-2 pairings: an unpaired baseline `tests/` function can currently name-match an unrelated new `src/` function and report a fake `Moved`/`Regressed`.
- `--min`/`--top` are explicitly out of scope (score/rank-based, not identity-based; filtering the baseline by them would mask genuine changes).

Specs only — no code changes. `just dev` is clean.
