### PR TITLE
feat(shields): embed threshold in badge label (spec 15 amendment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,28 @@ jobs:
       - name: Generate coverage
         run: cargo llvm-cov --lcov --output-path lcov.info --workspace
 
+      # --- On main: generate the README badge JSON (spec 15). Runs *before*
+      # the threshold gate so a failing gate still publishes a yellow/red
+      # badge instead of leaving a stale green one. The `badge` job
+      # downloads the artifact and pushes it to the `badges` branch — this
+      # job deliberately has no `contents: write`.
+      - name: Generate badge JSON (main only)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cargo run --release -- \
+            --lcov lcov.info \
+            --workspace \
+            --exclude 'tests/fixtures/**' \
+            --threshold 15 \
+            --format shields \
+            --output crap-badge.json
+      - name: Upload badge artifact (main only)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: crap-badge
+          path: crap-badge.json
+
       # --- Absolute threshold gate (always) ---
       - name: Score (threshold 15, exclude fixtures)
         run: |
@@ -178,27 +200,6 @@ jobs:
           name: crap-baseline
           path: crap-current.json
           retention-days: 90
-
-      # --- On main: generate the README badge JSON (spec 15). The lcov file
-      # already exists from the gate above, so this is just one extra render.
-      # The `badge` job downloads the artifact and publishes it to the
-      # `badges` branch — this job deliberately has no `contents: write`.
-      - name: Generate badge JSON (main only)
-        if: github.ref == 'refs/heads/main'
-        run: |
-          cargo run --release -- \
-            --lcov lcov.info \
-            --workspace \
-            --exclude 'tests/fixtures/**' \
-            --threshold 15 \
-            --format shields \
-            --output crap-badge.json
-      - name: Upload badge artifact (main only)
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: crap-badge
-          path: crap-badge.json
 
       # --- On PRs: download the baseline uploaded by the latest successful
       # main run. `actions/download-artifact@v4` only sees the *current*
@@ -329,22 +330,35 @@ jobs:
   badge:
     name: Publish CRAP badge
     needs: [self_score]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # `always()` + result filter: publish on self_score success *and*
+    # failure (a failing threshold gate is exactly when the badge must turn
+    # yellow/red), but not when self_score was skipped by the changes gate.
+    if: >-
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      && contains(fromJSON('["success", "failure"]'), needs.self_score.result)
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+      # The artifact is missing when self_score failed before the badge was
+      # generated (e.g. a broken coverage build) — skip publishing then.
       - name: Download badge artifact
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: crap-badge
           path: .
+        continue-on-error: true
       # Build a single-file orphan commit with git plumbing and force-push it
       # to `badges` — no checkout dance, and the branch never accumulates
       # history.
       - name: Push badge to the badges branch
         run: |
+          if [ ! -f crap-badge.json ]; then
+            echo "No badge artifact — self_score failed before generating it; skipping."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           blob=$(git hash-object -w crap-badge.json)

--- a/README.md
+++ b/README.md
@@ -196,10 +196,11 @@ normal badge image:
 ![CRAP](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/owner/repo/main/crap-badge.json)
 ```
 
-The badge message is `passing` (brightgreen) when no function exceeds
-`--threshold`, `N crappy` in yellow for 1–5 offenders, and red for 6 or
-more. `--baseline` is silently ignored — the badge always reflects
-absolute current scores. See [Badge generation](#badge-generation) for a
+The label embeds the effective threshold (`CRAP > 15`) so the badge reads
+as a complete statement. The message is `passing` (brightgreen) when no
+function exceeds `--threshold`, `N crappy` in yellow for 1–5 offenders,
+and red for 6 or more. `--baseline` is silently ignored — the badge
+always reflects absolute current scores. See [Badge generation](#badge-generation) for a
 CI recipe.
 
 ## Configuration file

--- a/specs/15-shields-badge.md
+++ b/specs/15-shields-badge.md
@@ -31,11 +31,18 @@ The output is a single JSON object following the
 ```json
 {
   "schemaVersion": 1,
-  "label": "CRAP",
+  "label": "CRAP > <threshold>",
   "message": "<message>",
   "color": "<color>"
 }
 ```
+
+### Label rule
+
+The label embeds the effective threshold so the badge reads as a complete
+statement ("no function has CRAP above 15"): `CRAP > <threshold>`, where
+`<threshold>` is formatted without trailing zeros (`15`, not `15.0`;
+fractional thresholds like `12.5` keep their fraction).
 
 ### Message and color rules
 
@@ -45,7 +52,8 @@ The output is a single JSON object following the
 | 1 – 5                     | `N crappy`     | `yellow`      |
 | 6+                        | `N crappy`     | `red`         |
 
-`N` is the count of functions whose CRAP score exceeds `--threshold`.
+`N` is the count of functions whose CRAP score exceeds `--threshold`
+(strictly greater — a function exactly at the threshold passes).
 
 ---
 
@@ -58,7 +66,7 @@ Given a project where no function exceeds the threshold
 When  I run `cargo crap --format shields --output crap-badge.json`
 Then  crap-badge.json contains valid JSON
 And   "schemaVersion" is 1
-And   "label" is "CRAP"
+And   "label" is "CRAP > 30"   (the default threshold)
 And   "message" is "passing"
 And   "color" is "brightgreen"
 ```
@@ -87,6 +95,7 @@ And   "color" is "red"
 Given a project with functions at various CRAP scores
 When  I run `cargo crap --format shields --threshold 50`
 Then  only functions with CRAP > 50 are counted toward the badge message
+And   "label" is "CRAP > 50"
 ```
 
 ### Scenario: Output written to --output file

--- a/src/report/shields.rs
+++ b/src/report/shields.rs
@@ -15,16 +15,25 @@ use std::io::Write;
 
 /// Shields.io endpoint schema version — always 1 per the published schema.
 const SCHEMA_VERSION: u32 = 1;
-const LABEL: &str = "CRAP";
 
 /// The [Shields.io endpoint schema v1](https://shields.io/endpoint) object.
 #[derive(Serialize)]
 struct Badge {
     #[serde(rename = "schemaVersion")]
     schema_version: u32,
-    label: &'static str,
+    label: String,
     message: String,
     color: &'static str,
+}
+
+/// Format the threshold for the badge label without trailing zeros:
+/// `15`, not `15.0` — but `12.5` keeps its fraction.
+fn format_threshold(threshold: f64) -> String {
+    if threshold.fract() == 0.0 {
+        format!("{threshold:.0}")
+    } else {
+        format!("{threshold}")
+    }
 }
 
 pub(crate) fn render_shields(
@@ -32,7 +41,7 @@ pub(crate) fn render_shields(
     threshold: f64,
     out: &mut dyn Write,
 ) -> Result<()> {
-    write_badge(super::crappy_count(entries, threshold), out)
+    write_badge(super::crappy_count(entries, threshold), threshold, out)
 }
 
 /// Delta-mode dispatch target. The badge ignores the baseline entirely and
@@ -48,11 +57,12 @@ pub(crate) fn render_delta_shields(
         .iter()
         .filter(|e| Severity::classify(e.current.crap, threshold) == Severity::Crappy)
         .count();
-    write_badge(count, out)
+    write_badge(count, threshold, out)
 }
 
 fn write_badge(
     count: usize,
+    threshold: f64,
     out: &mut dyn Write,
 ) -> Result<()> {
     let (message, color) = match count {
@@ -62,7 +72,7 @@ fn write_badge(
     };
     let badge = Badge {
         schema_version: SCHEMA_VERSION,
-        label: LABEL,
+        label: format!("CRAP > {}", format_threshold(threshold)),
         message,
         color,
     };
@@ -79,7 +89,7 @@ mod tests {
 
     fn badge_value(count: usize) -> serde_json::Value {
         let mut buf = Vec::new();
-        super::write_badge(count, &mut buf).unwrap();
+        super::write_badge(count, 30.0, &mut buf).unwrap();
         serde_json::from_slice(&buf).expect("output must be valid JSON")
     }
 
@@ -87,9 +97,20 @@ mod tests {
     fn zero_crappy_is_a_passing_brightgreen_badge() {
         let v = badge_value(0);
         assert_eq!(v["schemaVersion"].as_u64(), Some(1));
-        assert_eq!(v["label"].as_str(), Some("CRAP"));
+        assert_eq!(v["label"].as_str(), Some("CRAP > 30"));
         assert_eq!(v["message"].as_str(), Some("passing"));
         assert_eq!(v["color"].as_str(), Some("brightgreen"));
+    }
+
+    #[test]
+    fn label_formats_integral_threshold_without_trailing_zeros() {
+        assert_eq!(super::format_threshold(15.0), "15");
+        assert_eq!(super::format_threshold(30.0), "30");
+    }
+
+    #[test]
+    fn label_keeps_fractional_threshold() {
+        assert_eq!(super::format_threshold(12.5), "12.5");
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -866,7 +866,7 @@ fn shields_output_is_a_valid_endpoint_badge() {
     let stdout = String::from_utf8(output.stdout).expect("utf8");
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(v["schemaVersion"].as_u64(), Some(1));
-    assert_eq!(v["label"].as_str(), Some("CRAP"));
+    assert_eq!(v["label"].as_str(), Some("CRAP > 30"));
     assert_eq!(v["message"].as_str(), Some("1 crappy"));
     assert_eq!(v["color"].as_str(), Some("yellow"));
 }
@@ -884,6 +884,7 @@ fn shields_with_high_threshold_is_passing_brightgreen() {
         .expect("run");
     let stdout = String::from_utf8(output.stdout).expect("utf8");
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["label"].as_str(), Some("CRAP > 10000"));
     assert_eq!(v["message"].as_str(), Some("passing"));
     assert_eq!(v["color"].as_str(), Some("brightgreen"));
 }
@@ -913,7 +914,7 @@ fn shields_output_flag_writes_badge_file_and_keeps_stdout_empty() {
     let content = std::fs::read_to_string(&badge_path).expect("badge file must exist");
     let v: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
     assert_eq!(v["schemaVersion"].as_u64(), Some(1));
-    assert_eq!(v["label"].as_str(), Some("CRAP"));
+    assert_eq!(v["label"].as_str(), Some("CRAP > 30"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #40, approved spec-15 amendment: `CRAP | PASSING` didn't say what passed.

### Badge label
- Label is now `CRAP > <threshold>` (trailing zeros trimmed: `15`, not `15.0`; `12.5` keeps its fraction), so the badge reads as a complete statement — "no function has CRAP above 15."
- Message/color rules unchanged: `passing`/brightgreen, `N crappy` yellow (1–5) / red (6+).
- Spec 15 updated accordingly (label rule, acceptance tests, strict-`>` clarification).

### CI fix
- Badge JSON is now generated **before** the `--fail-above` gate in `self_score`, and the `badge` job publishes on self_score success *and* failure (`always()` + result filter). Previously, a failing threshold gate on main would have skipped badge generation and left a stale green badge — exactly the moment it should turn yellow/red.
- If self_score fails before the badge is generated (e.g. broken coverage build), the publish step skips gracefully.

### Checks
- `just dev` clean (dogfood: 140 functions, none above threshold 15).
- `just dev-mutants-diff` clean: 9 mutants tested, 9 caught.

Note: the Self-score check may show the same expected +1-CC regressions as #40 if the baseline artifact predates that merge.