### PR TITLE
docs(specs): add specs 19 and 20 — human-format display cap and width-aware table

### DIFF
--- a/specs/19-human-display-cap.md
+++ b/specs/19-human-display-cap.md
@@ -1,0 +1,125 @@
+# Spec 19 — Human-format display cap
+
+**Status:** Proposed
+**Effort:** Medium
+**Module:** `src/report/human.rs`
+
+## Context
+
+`--format human` prints one row per analyzed function. On large projects this
+produces thousands of rows, almost all of them below the threshold and
+therefore not actionable — a passing run on a 140-function project prints a
+140-row table just to say "nothing to do here."
+
+The actionable rows are the ones above the threshold. Below-threshold rows
+are only interesting as "hot spots": the handful of functions closest to
+crossing the line. Everything else is noise in a terminal, and the exhaustive
+listings already have dedicated formats (`json`, `markdown`).
+
+This spec applies to `--format human` only. All other formats are unchanged.
+
+---
+
+## Display rule
+
+After sorting by CRAP score descending:
+
+- **Above-threshold entries are always shown** — all of them. They are the
+  failures; capping them would hide the reason a CI gate went red.
+- **Below-threshold entries show only the 10 worst** ("hot spots").
+- When below-threshold rows were hidden, a single footer line reports the
+  count and the escape hatches:
+
+  ```
+  · 130 more below threshold — use --top, --min, or --format markdown for the full list.
+  ```
+
+- An explicit `--top N` or `--min S` disables the implicit cap entirely: the
+  user asked for a specific slice and gets exactly that slice, as today.
+- In delta mode (`--baseline`), `Regressed` rows are always shown even when
+  below threshold — a regression is actionable regardless of its absolute
+  score. The cap otherwise applies identically.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Passing run shows only the 10 worst hot spots
+
+```
+Given a project with 140 functions, none above the threshold
+When  I run `cargo crap --format human`
+Then  the table contains exactly 10 rows
+And   a footer reports "130 more below threshold"
+And   the summary line still reports all 140 analyzed functions
+```
+
+### Scenario: Above-threshold entries are never hidden
+
+```
+Given a project with 23 functions above the threshold and 200 below
+When  I run `cargo crap --format human`
+Then  all 23 above-threshold rows are shown
+And   exactly 10 below-threshold hot-spot rows follow them
+And   a footer reports "190 more below threshold"
+```
+
+### Scenario: Ten or fewer below-threshold entries means no footer
+
+```
+Given a project with 8 functions, none above the threshold
+When  I run `cargo crap --format human`
+Then  all 8 rows are shown
+And   no hidden-count footer is printed
+```
+
+### Scenario: Explicit --top disables the implicit cap
+
+```
+Given a project with 140 functions, none above the threshold
+When  I run `cargo crap --format human --top 50`
+Then  the table contains exactly 50 rows
+And   no hidden-count footer is printed
+```
+
+### Scenario: Explicit --min disables the implicit cap
+
+```
+Given a project with 140 functions, 40 of them with CRAP above 5
+When  I run `cargo crap --format human --min 5`
+Then  the table contains exactly 40 rows
+And   no hidden-count footer is printed
+```
+
+### Scenario: Regressed rows are exempt from the cap in delta mode
+
+```
+Given a baseline where 15 below-threshold functions have regressed
+When  I run `cargo crap --format human --baseline baseline.json`
+Then  all 15 regressed rows are shown
+And   at most 10 non-regressed below-threshold rows follow them
+```
+
+### Scenario: Other formats are unaffected
+
+```
+Given a project with 140 functions, none above the threshold
+When  I run `cargo crap --format json` (or markdown, github, sarif, pr-comment)
+Then  the output contains all 140 entries, exactly as before
+```
+
+---
+
+## Implementation Notes
+
+- The cap is a *display* concern: it lives in `render_human` /
+  `render_delta_human`, not in `apply_filters`. The entry list handed to
+  exit-code logic (`crappy_count`, `regression_count`) and to other formats
+  is never truncated.
+- `render_human` needs to know whether `--top` / `--min` were given so the
+  implicit cap can step aside; thread a flag (or the partitioned row sets)
+  through `RenderOpts` rather than re-deriving it inside the renderer.
+- The hot-spot count is a fixed constant (10). No new CLI flag: `--top` is
+  already the override. A config key can be added later if demand appears.
+- The footer is plain text outside the table so it never affects column
+  widths.

--- a/specs/20-human-width-aware-table.md
+++ b/specs/20-human-width-aware-table.md
@@ -1,0 +1,133 @@
+# Spec 20 — Width-aware human table
+
+**Status:** Proposed
+**Effort:** Medium
+**Module:** `src/report/human.rs`, `src/report/types.rs`
+
+## Context
+
+The human-format table derives its column widths purely from content. Long
+paths (`src/report/pr_comment.rs:380`) routinely push the table wider than
+the terminal, and the terminal then hard-wraps the box-drawing characters —
+the table "breaks" on anything narrower than the widest row.
+
+The fix is to measure the available width once at render time and lay the
+table out to fit it. Out of scope: re-flowing after the user resizes the
+window post-print — a one-shot CLI cannot reflow text it has already
+emitted; that would require a TUI.
+
+This spec applies to `--format human` only (absolute and delta tables, and
+the per-crate rollup table in `--workspace` mode).
+
+---
+
+## Width detection
+
+- stdout is a TTY → the current terminal width.
+- stdout is not a TTY (pipe, CI log) → `$COLUMNS` when set and parseable,
+  otherwise a fixed 120.
+
+## Degradation ladder
+
+Columns degrade in a fixed priority order as width shrinks. At every width
+the rendered table must fit — no overflowing box-drawing characters.
+
+| Available width | Layout                                                            |
+|-----------------|-------------------------------------------------------------------|
+| ≥ 100           | Full layout as today (10-cell coverage bar)                       |
+| 80 – 99         | Coverage bar shrinks to 5 cells; Location middle-truncated        |
+| 60 – 79         | Bar dropped (percent kept); long Function names trailing-truncated |
+| < 60            | CC column dropped; grade, CRAP, Function, Location remain         |
+
+- Location truncation keeps the tail: `…/pr_comment.rs:380`. The
+  `<file>.rs:<line>` suffix must always survive so the output stays
+  greppable and clickable.
+- The grade-marker, CRAP, and Function columns are never dropped.
+- The delta table's Δ column counts as part of the numeric block and is
+  never dropped (delta mode is opt-in and its column is the point).
+
+---
+
+## Acceptance Tests
+
+### Scenario: Wide terminal renders the full layout
+
+```
+Given a terminal 120 columns wide
+When  I run `cargo crap --format human`
+Then  the table shows the grade, CRAP, CC, Coverage (10-cell bar), Function, and Location columns
+And   no rendered line exceeds 120 columns
+```
+
+### Scenario: 80-column terminal fits without wrapping
+
+```
+Given a terminal 80 columns wide
+And   a project containing the path src/report/pr_comment.rs
+When  I run `cargo crap --format human`
+Then  no rendered line exceeds 80 columns
+And   the Location cell ends with "pr_comment.rs:" followed by the line number
+```
+
+### Scenario: 70-column terminal drops the coverage bar
+
+```
+Given a terminal 70 columns wide
+When  I run `cargo crap --format human`
+Then  no rendered line exceeds 70 columns
+And   the Coverage column shows the percentage without a bar
+```
+
+### Scenario: 50-column terminal drops the CC column
+
+```
+Given a terminal 50 columns wide
+When  I run `cargo crap --format human`
+Then  no rendered line exceeds 50 columns
+And   the table has no CC column
+And   the CRAP, Function, and Location columns are present
+```
+
+### Scenario: Piped output uses $COLUMNS
+
+```
+Given stdout is a pipe
+And   the environment variable COLUMNS=80
+When  I run `cargo crap --format human`
+Then  no rendered line exceeds 80 columns
+```
+
+### Scenario: Piped output without $COLUMNS uses 120
+
+```
+Given stdout is a pipe
+And   COLUMNS is unset
+When  I run `cargo crap --format human`
+Then  no rendered line exceeds 120 columns
+```
+
+### Scenario: Other formats are unaffected
+
+```
+Given any terminal width
+When  I run `cargo crap --format markdown` (or json, github, sarif, pr-comment)
+Then  the output is identical regardless of terminal width
+```
+
+---
+
+## Implementation Notes
+
+- comfy-table supports `set_content_arrangement(ContentArrangement::Dynamic)`
+  plus `Table::set_width`; detection can use `comfy_table`'s own
+  terminal-size probe (crossterm) for the TTY case. The `$COLUMNS` / 120
+  fallback for the non-TTY case is ours.
+- Column dropping and bar shrinking are decided *before* rows are built
+  (one decision per table from the measured width), not per row — every row
+  must agree on the layout.
+- The Location middle-truncation helper belongs in `report/types.rs` next to
+  `coverage_bar`; it needs unit tests for the keep-the-tail invariant,
+  including paths shorter than the budget (returned unchanged).
+- Width-driven layouts are testable without a real TTY by injecting the
+  measured width into the table builder; CLI tests can pin the `$COLUMNS`
+  scenarios via `assert_cmd`'s `env()`.


### PR DESCRIPTION
## Summary

Two new proposed specs addressing `--format human` ergonomics on large projects (huge tables, broken layout on narrow terminals).

### Spec 19 — display cap
- Above-threshold rows always print (they're the failures); below-threshold rows show only the 10 worst as hot spots, plus a one-line hidden-count footer with escape hatches (`--top`, `--min`, `--format markdown`).
- Explicit `--top`/`--min` disables the implicit cap.
- Delta mode: `Regressed` rows are exempt from the cap.
- Display-only: exit codes, JSON/markdown/other formats untouched.

### Spec 20 — width-aware table
- Measure width once at render time (TTY width; `$COLUMNS` or 120 when piped) and degrade columns in a fixed ladder: shrink coverage bar → middle-truncate Location (always keeping `file.rs:line`) → drop bar → drop CC.
- No rendered line may exceed the measured width — fixes the hard-wrapped box-drawing on narrow terminals.
- Post-print reflow on window resize is explicitly out of scope (one-shot CLI, not a TUI).

Both specs are `Proposed`; implementation to follow in separate PRs after review.