### PR TITLE
fix: flush --output writer before fail-gate exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -849,6 +849,9 @@ fn main() -> Result<()> {
     };
     let (has_crappy, has_regression) =
         do_render(&entries, baseline_data.as_deref(), &opts, out_box.as_mut())?;
+    // `std::process::exit` below skips destructors, so the BufWriter around
+    // `--output` must be flushed here or the report file is left empty (#47).
+    out_box.flush().context("flushing output")?;
 
     if (fail_above && has_crappy) || (fail_regression && has_regression) {
         std::process::exit(1);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1755,6 +1755,62 @@ fn fail_regression_exits_one_when_regression_exists() {
         .failure(); // crappy went from 1.0 → 156.0 → regression
 }
 
+#[test]
+fn fail_regression_still_writes_output_file_before_exiting() {
+    // Regression test for #47: `std::process::exit(1)` skips destructors, so
+    // the BufWriter around `--output` was never flushed and the report file
+    // was left truncated at 0 bytes. The gate must still write the report.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = regression_baseline(&dir);
+    let report_path = dir.path().join("report.json");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--fail-regression")
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&report_path)
+        .assert()
+        .failure();
+
+    let report = std::fs::read_to_string(&report_path).expect("report file must exist");
+    let json: serde_json::Value =
+        serde_json::from_str(&report).expect("report must be complete valid JSON");
+    assert!(
+        json["entries"]
+            .as_array()
+            .is_some_and(|e| e.iter().any(|x| x["status"] == "regressed")),
+        "flushed report should contain the regressed entry, got: {report}"
+    );
+
+    // Same gate with --summary: the (text) summary must also survive the exit.
+    let summary_path = dir.path().join("summary.txt");
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--fail-regression")
+        .arg("--summary")
+        .arg("--output")
+        .arg(&summary_path)
+        .assert()
+        .failure();
+    let summary = std::fs::read_to_string(&summary_path).expect("summary file must exist");
+    assert!(
+        summary.contains("↑ 1 regressed"),
+        "flushed summary should count exactly one regression, got: {summary}"
+    );
+}
+
 // --- --fail-above combined with --baseline (baseline path in do_render) ---
 
 #[test]


### PR DESCRIPTION
Fixes #47.

## Problem

`--baseline … --fail-regression --format json --output report.json` exited 1 correctly on a regression, but `report.json` was left **0 bytes**. `std::process::exit(1)` skips destructors, so the `BufWriter` wrapping the `--output` file was never flushed — `File::create` had already truncated the file, and the buffered report died with the process. Reports larger than the 8 KB buffer would have been silently truncated mid-JSON instead.

## Fix

Flush `out_box` explicitly right after `do_render`, before the exit-code gate. A side benefit: flush errors (e.g. ENOSPC) now surface as a real error instead of being silently swallowed by `BufWriter::drop`, so a truncated report can no longer masquerade as a successful run.

## Tests

New CLI regression test `fail_regression_still_writes_output_file_before_exiting` covers both the `--format json` case (file must be complete, parseable JSON containing the regressed entry) and the `--summary` case from the original report (the summary line must survive the exit; being a single short line it is guaranteed to still be buffer-resident, making it the strictest guard for this bug).

- `just dev` clean (fmt, clippy, tests, dogfood)
- `just dev-mutants-diff` clean: 81 mutants on `src/main.rs`, 69 caught, 12 unviable, 0 missed