### PR TITLE
fix: suffix-aware baseline matching for cross-root baselines (spec 21)

### DIFF
--- a/specs/21-suffix-aware-baseline-matching.md
+++ b/specs/21-suffix-aware-baseline-matching.md
@@ -1,0 +1,176 @@
+# Spec 21 — Suffix-aware baseline matching
+
+**Status:** Implemented
+**Effort:** Medium
+**Module:** `src/delta.rs`
+
+## Context
+
+`compute_delta` pass 1 joins current entries against the baseline by exact
+`(file_path, function_name, start_line)` string equality. When the baseline
+was recorded under a different checkout root than the current analysis —
+a CI baseline at `/app/src/backup.rs` compared on a developer machine at
+`/home/user/project/src/backup.rs` — pass 1 matches nothing, and the entire
+join collapses onto the spec-13 name-only fallback (issue #46). That
+fallback was designed for occasional file moves, not as a primary matcher:
+
+- Unique names pair up, but as `Moved` — the report claims the whole
+  codebase relocated.
+- Duplicate names (a free function `run_backup` defined in two modules)
+  stay unpaired and are misreported as `New` + `removed`, spuriously
+  failing `--fail-regression`.
+- Worst case, a name that is unique per side but belongs to genuinely
+  different files cross-pairs with the wrong baseline entry, silently
+  swallowing a real regression.
+
+The same collapse happens on one machine when the baseline stores absolute
+paths but the analysis was invoked with a relative `--path` (or vice
+versa).
+
+This spec inserts a suffix-aware pass between the exact join (pass 1) and
+the name-only fallback (pass 2): same-name entries whose file paths share
+their longest common component-suffix are paired as the *same logical
+file*. Function identity becomes deterministic under root remapping, as
+requested in #46.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Cross-root baseline matches exactly
+
+```
+Given a baseline entry at `/app/src/backup.rs:run_backup` with crap=5.0
+And   a current entry at `/home/user/project/src/backup.rs:run_backup`
+      with crap=5.0
+When  compute_delta runs
+Then  the entry is matched (status `Unchanged`)
+And   `previous_file` is None — a root remap is not a move
+And   the function appears in neither the `new` count nor `removed`
+```
+
+### Scenario: Duplicate function names disambiguate by directory suffix
+
+```
+Given baseline entries `/app/src/backup.rs:run` and `/app/src/restore.rs:run`
+And   current entries `/work/co/src/backup.rs:run` and
+      `/work/co/src/restore.rs:run`
+When  compute_delta runs
+Then  `src/backup.rs:run` pairs with the baseline `src/backup.rs:run`
+And   `src/restore.rs:run` pairs with the baseline `src/restore.rs:run`
+And   nothing is reported `New`, `Moved`, or `removed`
+```
+
+### Scenario: Regression across roots still fires the gate
+
+```
+Given a baseline entry at `/app/src/backup.rs:run` with crap=5.0
+And   a current entry at `/work/co/src/backup.rs:run` with crap=12.0
+And   another same-named pair `src/restore.rs:run` unchanged on both sides
+When  compute_delta runs with --fail-regression (epsilon 0.01)
+Then  the `src/backup.rs:run` entry has status `Regressed` with delta +7.0
+And   the exit code is 1
+```
+
+### Scenario: Relative current paths match an absolute baseline
+
+```
+Given a baseline entry at `/home/user/project/src/lib.rs:parse`
+And   a current entry at `src/lib.rs:parse`
+When  compute_delta runs
+Then  the entry is matched (one path is a component-suffix of the other)
+And   `previous_file` is None
+```
+
+### Scenario: Equal-length suffix ties stay unpaired
+
+```
+Given one unmatched baseline entry `/app/x/util.rs:helper`
+And   two unmatched current entries `a/util.rs:helper` and `b/util.rs:helper`
+When  compute_delta runs
+Then  no suffix pairing is made — both candidates tie at suffix `util.rs`
+And   the name-only fallback also declines (two current-side candidates)
+And   the baseline entry lands in `removed`; both current entries stay `New`
+```
+
+### Scenario: Line shifts do not break suffix matching
+
+```
+Given a baseline entry at `/app/src/lib.rs:parse` line 10
+And   a current entry at `/work/co/src/lib.rs:parse` line 42
+When  compute_delta runs
+Then  the entries pair (suffix matching ignores the start line)
+```
+
+### Scenario: Spec-13 moves are unaffected
+
+```
+Given a baseline entry at `src/old.rs:render`
+And   a current entry at `src/new.rs:render` with an identical score
+And   no other entry named `render` on either side
+When  compute_delta runs
+Then  the filenames share no component-suffix, so the suffix pass declines
+And   the name-only fallback pairs them as `Moved` with
+      `previous_file = src/old.rs` (spec 13 behaviour, unchanged)
+```
+
+### Scenario: Exact path match still takes precedence
+
+```
+Given baseline entries `src/a.rs:helper` and `src/b.rs:helper`
+And   current entries `src/a.rs:helper` (same line) and `src/c.rs:helper`
+When  compute_delta runs
+Then  `src/a.rs:helper` matches on pass 1 (exact)
+And   the suffix pass does not re-pair it with `src/b.rs`
+And   the leftovers (`src/b.rs` baseline, `src/c.rs` current — one `helper`
+      per side, no shared suffix) pair through the spec-13 name fallback
+      as a move, exactly as before this spec
+```
+
+---
+
+## Implementation Notes
+
+### Algorithm (`src/delta.rs`)
+
+A new pass 1.5 runs between `pass_one_exact` and `pass_two_name_fallback`,
+operating on the same material as pass 2 (current entries still `New`,
+baseline entries not yet matched), grouped by function name:
+
+```
+for each function name present in both unmatched sides:
+    for every (current, baseline) cross pair, score = number of trailing
+        path components the two files share (paths normalized to '/');
+    a pair is made iff score >= 1 (same filename) AND the pair is each
+        side's unique best (mutual unique argmax — any tie disqualifies
+        both candidates).
+```
+
+Paired entries are filled exactly like pass-1 matches: `baseline_crap`,
+`delta`, epsilon-classified status, `previous_file = None`. The baseline
+key is added to `matched` so `collect_removed` and pass 2 skip it.
+
+- One round only — no fixpoint iteration. Ties stay unpaired; determinism
+  over cleverness, mirroring spec 13's ambiguity philosophy.
+- The start line is deliberately ignored (unlike pass 1's `EntryKey`), so
+  a cross-root baseline still matches when unrelated edits shifted a
+  function.
+- Suffix comparison uses the same forward-slash normalization as
+  `path_key` so Windows baselines compare against POSIX paths.
+
+### Accepted trade-off
+
+A file move that keeps the filename (`old_dir/render.rs` →
+`new_dir/render.rs`) now pairs via the suffix pass and is reported as a
+plain match (`Unchanged`), not `Moved`. Root remapping and same-filename
+directory moves are indistinguishable without knowing each side's root,
+and misreporting a remapped root as "everything moved" (or worse,
+mispairing duplicates) costs more than losing the `Moved` badge on this
+subcase. Filename-changing moves keep full spec-13 `Moved` reporting.
+
+### Non-goals
+
+- No change to `EntryKey` / pass 1 exactness.
+- No change to the spec-18 baseline pre-filtering.
+- No new CLI flags or config keys — the pass always runs; its worst case
+  is declining to pair (existing behaviour).

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -241,6 +241,127 @@ fn apply_move_pairing(
     };
 }
 
+/// Apply a suffix pairing in place: same logical file under a different
+/// root, so the entry is filled exactly like a pass-1 match — score-based
+/// status, no `previous_file` (spec 21: a root remap is not a move).
+fn apply_suffix_pairing(
+    entry: &mut DeltaEntry,
+    baseline_entry: &CrapEntry,
+    epsilon: f64,
+) {
+    let d = entry.current.crap - baseline_entry.crap;
+    entry.baseline_crap = Some(baseline_entry.crap);
+    entry.delta = Some(d);
+    entry.status = classify_score(d, epsilon);
+}
+
+/// Number of trailing path components two files share, after forward-slash
+/// normalization. `0` means not even the filename matches.
+fn common_suffix_len(
+    a: &Path,
+    b: &Path,
+) -> usize {
+    let a = path_key(a);
+    let b = path_key(b);
+    a.split('/')
+        .rev()
+        .zip(b.split('/').rev())
+        .take_while(|(x, y)| x == y)
+        .count()
+}
+
+/// For `from`, find the index in `candidates` whose file shares the longest
+/// common path suffix with it. Returns `None` when no candidate shares at
+/// least the filename, or when the best score is tied (ambiguous).
+fn unique_best_by_suffix<T>(
+    from: &Path,
+    candidates: &[T],
+    file_of: impl Fn(&T) -> &Path,
+) -> Option<usize> {
+    let mut best: Option<(usize, usize)> = None; // (candidate idx, score)
+    let mut tied = false;
+    for (i, c) in candidates.iter().enumerate() {
+        let score = common_suffix_len(from, file_of(c));
+        if score == 0 {
+            continue;
+        }
+        match best {
+            None => best = Some((i, score)),
+            Some((_, s)) => match score.cmp(&s) {
+                std::cmp::Ordering::Equal => tied = true,
+                std::cmp::Ordering::Greater => {
+                    best = Some((i, score));
+                    tied = false;
+                },
+                std::cmp::Ordering::Less => {},
+            },
+        }
+    }
+    match (best, tied) {
+        (Some((i, _)), false) => Some(i),
+        _ => None,
+    }
+}
+
+/// Pass 1.5 — suffix-aware file match (spec 21). Among entries pass 1 left
+/// `New` and the unmatched baseline entries, pair same-name entries whose
+/// files share their longest common component-suffix (at minimum the
+/// filename), when each is the other's unique best. This keeps function
+/// identity deterministic when the baseline was recorded under a different
+/// checkout root, instead of collapsing onto the name-only fallback.
+///
+/// Scoring runs against a snapshot taken at pass start (one round, no
+/// fixpoint): the mutual-unique-best requirement already guarantees no
+/// baseline entry is assigned twice, and snapshot semantics keep the
+/// result independent of iteration order.
+fn pass_suffix_match(
+    entries: &mut [DeltaEntry],
+    baseline: &[CrapEntry],
+    matched: &mut HashSet<EntryKey>,
+    epsilon: f64,
+) {
+    let mut new_by_name: HashMap<String, Vec<(usize, PathBuf)>> = HashMap::new();
+    for (i, de) in entries.iter().enumerate() {
+        if de.status == DeltaStatus::New {
+            new_by_name
+                .entry(de.current.function.clone())
+                .or_default()
+                .push((i, de.current.file.clone()));
+        }
+    }
+    let mut baseline_by_name: HashMap<&str, Vec<&CrapEntry>> = HashMap::new();
+    for b in baseline {
+        if !matched.contains(&EntryKey::new(b)) {
+            baseline_by_name
+                .entry(b.function.as_str())
+                .or_default()
+                .push(b);
+        }
+    }
+    for (name, cur_group) in &new_by_name {
+        let Some(bas_group) = baseline_by_name.get(name.as_str()) else {
+            continue;
+        };
+        for (entry_idx, cur_file) in cur_group {
+            let Some(bi) = unique_best_by_suffix(cur_file, bas_group, |b| b.file.as_path()) else {
+                continue;
+            };
+            // Mutual unique best: the chosen baseline entry must pick this
+            // current entry back, or the pairing is ambiguous.
+            let Some(ci) =
+                unique_best_by_suffix(&bas_group[bi].file, cur_group, |(_, f)| f.as_path())
+            else {
+                continue;
+            };
+            if cur_group[ci].0 != *entry_idx {
+                continue;
+            }
+            apply_suffix_pairing(&mut entries[*entry_idx], bas_group[bi], epsilon);
+            matched.insert(EntryKey::new(bas_group[bi]));
+        }
+    }
+}
+
 /// Pass 2 — name-only fallback over the unmatched. Pairings happen only
 /// when a name appears exactly once on each side (the unambiguous case).
 fn pass_two_name_fallback(
@@ -301,15 +422,21 @@ fn collect_removed(
 
 /// Join current results against a baseline and compute per-function deltas.
 ///
-/// **Two-pass match** (spec 13):
+/// **Three-pass match** (specs 13 and 21):
 ///
-/// 1. Exact `(file_path, function_name)` pair — the original behaviour.
-/// 2. Among entries Pass 1 left as `New` (current side) and the unmatched
-///    baseline entries (Removed side), pair any function name that appears
-///    **exactly once** on each side. Score-unchanged pairings become
-///    [`DeltaStatus::Moved`]; score-changed pairings keep their
-///    `Regressed` / `Improved` status. Either way, the entry's
-///    `previous_file` records the baseline location.
+/// 1. Exact `(file_path, function_name, start_line)` pair — the original
+///    behaviour.
+/// 2. Suffix-aware file match (spec 21) — same-name entries whose files
+///    share their longest common component-suffix pair as the *same
+///    logical file* (root remap, absolute-vs-relative paths). Statuses
+///    follow the epsilon rule; `previous_file` stays `None`.
+/// 3. Name-only fallback (spec 13) — among entries still `New` (current
+///    side) and the unmatched baseline entries (Removed side), pair any
+///    function name that appears **exactly once** on each side.
+///    Score-unchanged pairings become [`DeltaStatus::Moved`];
+///    score-changed pairings keep their `Regressed` / `Improved` status.
+///    Either way, the entry's `previous_file` records the baseline
+///    location.
 ///
 /// Ambiguous names (multiple unmatched entries with the same name) are
 /// left unpaired — there's no way to tell which moved where. They keep
@@ -324,6 +451,7 @@ pub fn compute_delta(
     epsilon: f64,
 ) -> DeltaReport {
     let (mut entries, mut matched) = pass_one_exact(current, baseline, epsilon);
+    pass_suffix_match(&mut entries, baseline, &mut matched, epsilon);
     pass_two_name_fallback(&mut entries, baseline, &mut matched, epsilon);
     let removed = collect_removed(baseline, &matched);
     DeltaReport { entries, removed }
@@ -851,6 +979,253 @@ mod tests {
                 de.current.line
             );
         }
+        assert!(report.removed.is_empty());
+    }
+
+    fn entry_at(
+        file: &str,
+        function: &str,
+        crap: f64,
+    ) -> CrapEntry {
+        CrapEntry {
+            file: PathBuf::from(file),
+            function: function.to_string(),
+            line: 1,
+            cyclomatic: 1.0,
+            coverage: Some(100.0),
+            crap,
+            crate_name: None,
+        }
+    }
+
+    #[test]
+    fn cross_root_baseline_matches_without_move_status() {
+        // Kills: pass_suffix_match removed / apply_suffix_pairing setting
+        // previous_file. A root remap must match as the same logical file.
+        let baseline = vec![entry_at("/app/src/backup.rs", "run_backup", 5.0)];
+        let current = vec![entry_at(
+            "/home/user/project/src/backup.rs",
+            "run_backup",
+            5.0,
+        )];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert!(
+            report.entries[0].previous_file.is_none(),
+            "a root remap is not a move"
+        );
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn duplicate_names_disambiguate_by_directory_suffix() {
+        // The issue-#46 core case: `run` exists in two files; the name-only
+        // fallback cannot pair them, but directory suffixes can.
+        let baseline = vec![
+            entry_at("/app/src/backup.rs", "run", 5.0),
+            entry_at("/app/src/restore.rs", "run", 7.0),
+        ];
+        let current = vec![
+            entry_at("/work/co/src/backup.rs", "run", 5.0),
+            entry_at("/work/co/src/restore.rs", "run", 7.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        for de in &report.entries {
+            assert_eq!(
+                de.status,
+                DeltaStatus::Unchanged,
+                "{} must pair with its own file's baseline entry",
+                de.current.file.display()
+            );
+        }
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn cross_root_regression_pairs_with_the_right_file() {
+        // backup.rs regressed, restore.rs did not — the pairing must not
+        // cross the two files (which would hide the regression).
+        let baseline = vec![
+            entry_at("/app/src/backup.rs", "run", 5.0),
+            entry_at("/app/src/restore.rs", "run", 7.0),
+        ];
+        let current = vec![
+            entry_at("/work/co/src/backup.rs", "run", 12.0),
+            entry_at("/work/co/src/restore.rs", "run", 7.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.regression_count(), 1);
+        let regressed = report
+            .entries
+            .iter()
+            .find(|e| e.status == DeltaStatus::Regressed)
+            .expect("one regression");
+        assert!(regressed.current.file.ends_with("backup.rs"));
+        assert_eq!(regressed.baseline_crap, Some(5.0));
+        assert!((regressed.delta.unwrap() - 7.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn relative_current_matches_absolute_baseline() {
+        let baseline = vec![entry_at("/home/user/project/src/lib.rs", "parse", 3.0)];
+        let current = vec![entry_at("src/lib.rs", "parse", 3.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn equal_suffix_ties_stay_unpaired() {
+        // One baseline `util.rs:helper`, two current candidates tie at the
+        // filename — ambiguous, so nothing pairs (and the name fallback
+        // declines too: two current-side entries).
+        let baseline = vec![entry_at("/app/x/util.rs", "helper", 2.0)];
+        let current = vec![
+            entry_at("a/util.rs", "helper", 2.0),
+            entry_at("b/util.rs", "helper", 2.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        for de in &report.entries {
+            assert_eq!(de.status, DeltaStatus::New);
+        }
+        assert_eq!(report.removed.len(), 1);
+    }
+
+    #[test]
+    fn line_shift_does_not_break_suffix_matching() {
+        // Kills: adding a line-equality requirement to the suffix pass.
+        let mut b = entry_at("/app/src/lib.rs", "parse", 3.0);
+        b.line = 10;
+        let mut c = entry_at("/work/co/src/lib.rs", "parse", 3.0);
+        c.line = 42;
+        let report = compute_delta(&[c], &[b], DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn filename_change_still_reported_as_move() {
+        // Spec-13 behaviour preserved: no shared suffix → the suffix pass
+        // declines and the name fallback pairs it as Moved.
+        let baseline = vec![entry_at("src/old.rs", "render", 4.0)];
+        let current = vec![entry_at("src/new.rs", "render", 4.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Moved);
+        assert_eq!(
+            report.entries[0].previous_file,
+            Some(PathBuf::from("src/old.rs"))
+        );
+    }
+
+    #[test]
+    fn exact_match_takes_precedence_over_suffix() {
+        // `src/a.rs:helper` matches exactly on pass 1; the leftover baseline
+        // `src/b.rs:helper` must not steal it via the suffix pass (b.rs and
+        // a.rs share no suffix with each other's remaining candidates). The
+        // leftovers — one `helper` on each side — then pair through the
+        // spec-13 name fallback as a move, exactly as before spec 21.
+        let baseline = vec![
+            entry_at("src/a.rs", "helper", 2.0),
+            entry_at("src/b.rs", "helper", 9.0),
+        ];
+        let current = vec![
+            entry_at("src/a.rs", "helper", 2.0),
+            entry_at("src/c.rs", "helper", 2.0),
+        ];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        let a = report
+            .entries
+            .iter()
+            .find(|e| e.current.file.ends_with("a.rs"))
+            .expect("a.rs present");
+        assert_eq!(a.status, DeltaStatus::Unchanged);
+        assert_eq!(a.baseline_crap, Some(2.0), "a.rs must pair with a.rs");
+        assert!(
+            a.previous_file.is_none(),
+            "exact match must not be relabeled by later passes"
+        );
+        let c = report
+            .entries
+            .iter()
+            .find(|e| e.current.file.ends_with("c.rs"))
+            .expect("c.rs present");
+        assert_eq!(
+            c.status,
+            DeltaStatus::Improved,
+            "leftover unique name pairs via the spec-13 fallback"
+        );
+        assert_eq!(c.previous_file, Some(PathBuf::from("src/b.rs")));
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn deeper_suffix_wins_when_better_candidate_comes_first() {
+        // Kills: mutants in unique_best_by_suffix's replace logic that pick
+        // the later/worse candidate or flag spurious ties. The two baseline
+        // entries carry different scores so a wrong pick changes the delta.
+        let baseline = vec![
+            entry_at("/app/src/backup.rs", "run", 5.0), // suffix depth 2
+            entry_at("/app/legacy/backup.rs", "run", 9.0), // suffix depth 1
+        ];
+        let current = vec![entry_at("/co/src/backup.rs", "run", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert_eq!(
+            report.entries[0].baseline_crap,
+            Some(5.0),
+            "must pair with the deeper suffix (src/backup.rs), not legacy/"
+        );
+        assert_eq!(report.removed.len(), 1);
+        assert!(report.removed[0].file.ends_with("legacy/backup.rs"));
+    }
+
+    #[test]
+    fn deeper_suffix_wins_when_better_candidate_comes_second() {
+        // Same as above with the baseline order reversed: kills mutants
+        // that never replace the incumbent best candidate.
+        let baseline = vec![
+            entry_at("/app/legacy/backup.rs", "run", 9.0), // suffix depth 1
+            entry_at("/app/src/backup.rs", "run", 5.0),    // suffix depth 2
+        ];
+        let current = vec![entry_at("/co/src/backup.rs", "run", 5.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert_eq!(
+            report.entries[0].baseline_crap,
+            Some(5.0),
+            "the later, deeper-suffix candidate must replace the incumbent"
+        );
+    }
+
+    #[test]
+    fn tie_is_cleared_when_a_deeper_suffix_follows() {
+        // Two candidates tie at the filename, then a strictly deeper match
+        // arrives: the tie must be cleared and the pairing made. Kills
+        // mutants that drop the `tied = false` reset.
+        let baseline = vec![
+            entry_at("/r1/util.rs", "helper", 7.0),
+            entry_at("/r2/util.rs", "helper", 8.0),
+            entry_at("/app/src/util.rs", "helper", 3.0), // suffix depth 2
+        ];
+        let current = vec![entry_at("/co/src/util.rs", "helper", 3.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
+        assert_eq!(
+            report.entries[0].baseline_crap,
+            Some(3.0),
+            "the unique deepest suffix must pair despite the earlier tie"
+        );
+        assert_eq!(report.removed.len(), 2);
+    }
+
+    #[test]
+    fn windows_baseline_matches_posix_paths() {
+        // path_key normalizes back-slashes, so a baseline written on
+        // Windows pairs with POSIX analysis paths.
+        let baseline = vec![entry_at(r"C:\ci\app\src\lib.rs", "parse", 3.0)];
+        let current = vec![entry_at("/work/co/src/lib.rs", "parse", 3.0)];
+        let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
+        assert_eq!(report.entries[0].status, DeltaStatus::Unchanged);
         assert!(report.removed.is_empty());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3104,8 +3104,6 @@ fn workspace_baseline_entries_filtered_per_member_root() {
     );
 }
 
-// --- colour handling: no ANSI escapes outside a real terminal (PR #48 review) ---
-
 /// `cmd()` with the colour env vars cleared so the ambient environment
 /// (developer shell, CI) cannot flip the auto-detection under test.
 fn color_cmd() -> Command {
@@ -3214,5 +3212,67 @@ fn no_color_wins_over_force_color() {
     assert!(
         !stdout.contains('\u{1b}'),
         "NO_COLOR must beat FORCE_COLOR, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn cross_root_baseline_matches_all_functions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = dir.path().join("baseline.json");
+
+    // Record a baseline of the fixture, then rewrite every file path under
+    // a foreign checkout root, as if it had been generated in CI.
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&baseline_path)
+        .assert()
+        .success();
+    let baseline = std::fs::read_to_string(&baseline_path).expect("baseline");
+    let remapped = baseline.replace(
+        "tests/fixtures/sample_project/src",
+        "/ci/build/repo/tests/fixtures/sample_project/src",
+    );
+    assert_ne!(baseline, remapped, "remap must rewrite at least one path");
+    std::fs::write(&baseline_path, remapped).expect("write remapped baseline");
+
+    // The same analysis against the remapped baseline must pair every
+    // function as its own file's entry: nothing new, moved, or removed,
+    // and the regression gate stays green.
+    let assert = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--fail-regression")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
+    let envelope: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let entries = envelope["entries"].as_array().expect("entries array");
+    assert!(!entries.is_empty());
+    for e in entries {
+        assert_eq!(
+            e["status"], "unchanged",
+            "cross-root entry must match its own file, got: {e}"
+        );
+        assert!(
+            e.get("previous_file").is_none(),
+            "a root remap must not be reported as a move: {e}"
+        );
+    }
+    assert_eq!(
+        envelope["removed"].as_array().map(Vec::len),
+        Some(0),
+        "no baseline entry may be orphaned by the root remap"
     );
 }


### PR DESCRIPTION
Fixes #46.

## Problem

`compute_delta` pass 1 joins on exact path-string equality, so a baseline recorded under a different checkout root (CI at `/app/…`, dev machine at `/home/user/project/…`) matched **nothing**, and the whole join collapsed onto the spec-13 name-only fallback:

- unique names paired, but as `Moved` — "the whole codebase relocated";
- duplicate names (`run_backup` as a free function in two modules) stayed unpaired → misreported `New` + `removed`, spuriously failing `--fail-regression`;
- worst case, same-name functions in genuinely different files cross-paired, silently hiding a real regression.

Same collapse with an absolute-path baseline vs a relative `--path` run.

## Fix — spec 21 (new spec file included for review)

A new pass between the exact join and the name fallback: same-name entries pair by the **longest common path-component suffix** of their files (at minimum the filename), requiring each to be the other's unique best — any tie disqualifies both, one round, no fixpoint. Suffix pairs are treated as the *same logical file*: epsilon-classified status, no `Moved`, no `previous_file` (a root remap is not a move).

- Filename-changing moves (`src/old.rs` → `src/new.rs`) share no suffix, so they still flow through the spec-13 fallback unchanged — every spec-13 scenario keeps passing.
- Accepted trade-off (documented in the spec): a directory move that keeps the filename now reports as a plain match rather than `Moved`; root remaps and such moves are indistinguishable without knowing each side's root.
- Suffix comparison ignores the start line (a cross-root baseline still matches after unrelated edits shift a function) and normalizes back-slashes (Windows baselines vs POSIX paths).

## Tests

- 11 new unit tests in `delta.rs`: the #46 core case (duplicate names disambiguated by directory), regression pairing with the *right* file, relative-vs-absolute, suffix ties, line shifts, order-sensitivity of the best-candidate selection, tie-then-deeper-match, Windows paths, spec-13 move preservation, pass-1 precedence.
- End-to-end CLI test: records a real fixture baseline, rewrites every path under `/ci/build/…`, and asserts the rerun matches everything (`unchanged`, no `previous_file`, empty `removed`) with `--fail-regression` green.

- `just dev` clean (fmt, clippy, tests, dogfood)
- `just dev-mutants-diff` clean: 62 mutants on `src/delta.rs`, 54 caught, 8 unviable, 0 missed (6 earlier survivors killed by restructuring the best-candidate match to `Ordering` and adding the order-sensitive tests)