### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - 2026-07-19
+
+A bug-fix release: three defects around `--output` files and `--baseline`
+matching, all reported against 0.3.0 (issues #46, #47). No breaking changes.
+
+### Fixed
+
+- **`--format json --output` no longer writes a 0-byte report when a fail
+  gate trips** (#47). `std::process::exit(1)` skips destructors, so the
+  buffered `--output` writer was never flushed when `--fail-above` /
+  `--fail-regression` fired — CI gates saw exit code 1 plus an empty (or,
+  for reports over 8 KB, truncated) file. The writer is now flushed before
+  the exit-code decision, and flush errors (e.g. `ENOSPC`) surface as real
+  errors instead of being silently swallowed, so a truncated report can no
+  longer masquerade as a successful run.
+- **ANSI escape codes are no longer written into `--output` files or
+  pipes.** The `human` and `--summary` renderers coloured text
+  unconditionally, and the table styling keyed off stdout's TTY-ness even
+  when `--output` pointed at a file. Colour is now decided per sink: on
+  only when writing to stdout and stdout is a terminal. The standard
+  `NO_COLOR` (force off, wins over everything) and `FORCE_COLOR` (force
+  on, e.g. for `| less -R`) environment variables are respected. Library
+  consumers can drive this via the new `report::set_color_enabled`
+  (default: off).
+- **Cross-root baselines match deterministically** (#46, spec 21). A
+  baseline recorded under a different checkout root (CI at `/app/…`,
+  laptop elsewhere) or with absolute paths against a relative `--path` run
+  matched nothing exactly, collapsing onto the name-only move fallback:
+  duplicate function names were misreported as `New` + `removed`
+  (spuriously failing `--fail-regression`), unique names as `Moved`, and
+  same-name functions in different files could cross-pair and hide a real
+  regression. A new matching pass pairs same-name entries by the longest
+  common path suffix of their files (unambiguous pairings only) and treats
+  them as the same logical file. Note the one visible trade-off: a file
+  move that keeps the filename (`old_dir/render.rs` → `new_dir/render.rs`)
+  is now reported as a plain match rather than `Moved`;
+  filename-changing moves keep full spec-13 `Moved` reporting.
+
 ## [0.3.0] - 2026-06-15
 
 This release bundles specs 14–18. It contains **breaking changes** — see

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Oleksandr Prokhorenko <warbles.lieu_04@icloud.com>"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cargo-crap
 
-[![v0.3.0](https://img.shields.io/badge/v0.3.0-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.3.0)
+[![v0.3.1](https://img.shields.io/badge/v0.3.1-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.3.1)
 [![crates.io](https://img.shields.io/badge/crates.io-E57300?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/crates/cargo-crap)
-[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.3.0/cargo_crap/)
+[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.3.1/cargo_crap/)
 [![CRAP](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fminikin%2Fcargo-crap%2Fbadges%2Fcrap-badge.json&style=for-the-badge)](https://github.com/minikin/cargo-crap/actions/workflows/ci.yml)
 
 > [!TIP]


### PR DESCRIPTION
Bug-fix release bundling the three 0.3.0 defect fixes. No breaking changes.

- `--format json --output` wrote a 0-byte report when a fail gate tripped (#47, PR #48)
- ANSI escape codes were written into `--output` files and pipes; NO_COLOR/FORCE_COLOR now respected (PR #49)
- Cross-root baselines mispaired duplicate function names (#46, spec 21, PR #50)

Bumps `Cargo.toml` to 0.3.1, updates the README version badge and docs.rs link, adds the `[0.3.1]` CHANGELOG section.

**Merge order:** PR #50 first, then this. Tagging `v0.3.1` on main afterwards triggers the release workflow (binaries → GitHub release → crates.io).