### PR TITLE
docs(specs): add specs 23–25 for issues #53/#54/#55

### DIFF
--- a/specs/23-exit-code-contract.md
+++ b/specs/23-exit-code-contract.md
@@ -1,0 +1,114 @@
+# Spec 23 — Exit-code contract: policy failures vs tool errors
+
+**Status:** Proposed (issue #54)
+**Effort:** Small
+**Module:** `src/main.rs` (+ README, `tests/cli.rs`)
+
+## Context
+
+`--fail-above` and `--fail-regression` exit with code 1 when the gate
+trips — but so does every runtime error, because `main` returns
+`anyhow::Result` and the standard library maps `Err` to exit code 1.
+A CI wrapper cannot distinguish "the analysis ran and found a
+regression" from "the LCOV file was unreadable", which forces
+file-size and log-parsing heuristics downstream.
+
+The 0.3.1 flush fix (#47) guarantees the report file is complete
+before a gate exit; a stable exit-code contract completes the
+automation story.
+
+The contract (following the `grep` convention — 0 hit, 1 miss, 2
+error):
+
+| Code | Meaning                                                          |
+|------|------------------------------------------------------------------|
+| 0    | Analysis completed; no requested gate tripped.                   |
+| 1    | Analysis completed and the report was written; a requested gate (`--fail-above` / `--fail-regression`) tripped. |
+| 2    | The run did not complete: usage, input, analysis, or output error. |
+
+clap already exits 2 on usage errors, so class 2 unifies "anything
+that is not a finished CRAP verdict" under the code callers already
+see for bad flags. Existing callers that only test zero vs non-zero
+are unaffected.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Gate failure exits 1 with a complete report
+
+```
+Given a baseline and a current run containing a regression
+When  cargo-crap runs with --fail-regression --format json --output report.json
+Then  the exit code is 1
+And   report.json is complete, valid JSON containing the regressed entry
+```
+
+### Scenario: Clean pass exits 0
+
+```
+Given a run where no requested gate trips
+When  cargo-crap runs with --fail-above and no function exceeds the threshold
+Then  the exit code is 0
+```
+
+### Scenario: Invalid input exits 2, not 1
+
+```
+Given an --lcov argument pointing at a file that is not LCOV data
+When  cargo-crap runs
+Then  the exit code is 2
+And   stderr describes the parse failure
+```
+
+### Scenario: Unwritable output is distinguishable from a regression
+
+```
+Given an --output path inside a nonexistent directory
+When  cargo-crap runs with --fail-regression against a baseline with a regression
+Then  the exit code is 2 (the report could not be produced)
+And   the exit code is not 1 (a gate verdict was never reached)
+```
+
+### Scenario: Nonexistent --path exits 2
+
+```
+Given a --path that does not exist
+When  cargo-crap runs
+Then  the exit code is 2
+```
+
+### Scenario: Usage errors keep clap's exit 2
+
+```
+Given an unknown flag (e.g. --frobnicate)
+When  cargo-crap runs
+Then  the exit code is 2 (clap's default, now part of the documented contract)
+```
+
+---
+
+## Implementation Notes
+
+- `main` stops returning `anyhow::Result<()>`. It becomes a thin
+  wrapper returning `std::process::ExitCode`:
+  - delegate to a `run() -> anyhow::Result<ExitCode>` containing the
+    current body;
+  - `Err(e)` → print the error chain to stderr (preserve the current
+    `Error: …` + causes formatting, e.g. `eprintln!("Error: {e:?}")`)
+    → `ExitCode::from(2)`.
+- The gate branch replaces `std::process::exit(1)` with
+  `Ok(ExitCode::from(1))`. The explicit `out_box.flush()` from #47
+  stays (destructors now also run, but the flush must still precede
+  the verdict so an `ENOSPC` becomes exit 2, not a truncated file
+  with exit 1).
+- A flush/write error on `--output` is class 2 by construction — it
+  propagates as `Err` before the gate decision.
+- README: document the table above in the CI section.
+
+### Non-goals
+
+- No finer-grained error codes (LCOV vs config vs IO). One error
+  class is the contract; a machine-readable status file (floated in
+  issue #54) is a separate discussion.
+- No change to which conditions trip the gates.

--- a/specs/24-scope-mismatch-diagnostics.md
+++ b/specs/24-scope-mismatch-diagnostics.md
@@ -1,0 +1,143 @@
+# Spec 24 — Source/LCOV scope-mismatch diagnostics
+
+**Status:** Proposed (issue #53)
+**Effort:** Medium
+**Module:** `src/merge.rs`, `src/main.rs`, `src/report/json.rs`, `schemas/`
+
+## Context
+
+When the analyzed source tree and the LCOV file describe different
+scopes — e.g. an analysis root that recursively includes nested
+workspace packages absent from the LCOV — every function in the
+uncovered files scores as 0 % covered (`--missing pessimistic`), and a
+delta fills with entries that have nothing to do with the code change.
+The report looks like a mass CRAP regression when the real problem is
+a scope mismatch between the two inputs.
+
+Today's diagnostic surface is one stderr warning listing source files
+with no LCOV match — unbounded (it prints every path), counting
+nothing, invisible to machine consumers, and silent about the mirror
+case (LCOV records for files that were never analyzed).
+
+This spec makes the mismatch measurable and visible before the report:
+counts on both sides, bounded examples, a severity escalation for very
+low overlap, and the same numbers in the JSON envelope so CI wrappers
+can apply their own policy.
+
+Scores, gates, and `--missing` semantics are unchanged — this is
+diagnostics only.
+
+---
+
+## Acceptance Tests
+
+"Diagnostics" below means the five quantities:
+
+- `analyzed_files` — distinct source files that produced ≥ 1 analyzed function
+- `lcov_files` — distinct `SF` records in the LCOV file
+- `matched_files` — files present on both sides after path matching
+- `source_only` — analyzed files with no LCOV match (count + examples)
+- `lcov_only` — LCOV `SF` files matched by no analyzed file (count + examples)
+
+### Scenario: Matching scopes behave exactly as today
+
+```
+Given a source tree and an LCOV file where every analyzed file has an
+      LCOV record and vice versa
+When  cargo-crap runs
+Then  no scope warning is printed to stderr
+And   scores, ordering, and exit code are identical to the previous release
+And   JSON diagnostics report source_only = 0 and lcov_only = 0
+```
+
+### Scenario: Source scope wider than LCOV emits a bounded warning before the report
+
+```
+Given an analysis root containing 40 source files of which 25 have no
+      LCOV record
+When  cargo-crap runs with --baseline
+Then  stderr carries a scope-mismatch warning BEFORE the delta output
+And   the warning states analyzed/LCOV/matched counts and the
+      source-only count (25)
+And   it lists at most 10 example paths followed by "... and 15 more"
+And   the delta itself renders exactly as before
+```
+
+### Scenario: LCOV scope wider than source is also reported
+
+```
+Given an LCOV file carrying SF records for files outside the analysis root
+When  cargo-crap runs
+Then  the warning includes the lcov_only count and bounded examples
+      (e.g. hinting that --path/--workspace covers less than the
+      coverage run did)
+```
+
+### Scenario: Very low overlap escalates the warning
+
+```
+Given fewer than half of the analyzed files have an LCOV match
+When  cargo-crap runs
+Then  the warning leads with an explicit scope-mismatch verdict, e.g.
+      "warning: only 3 of 40 analyzed files match the LCOV report —
+      the analyzed tree and the coverage run likely describe
+      different scopes"
+And   with zero matches the wording says no overlap exists at all
+```
+
+### Scenario: JSON exposes the diagnostics
+
+```
+Given any run with --lcov and --format json
+When  the envelope is rendered (report or delta)
+Then  it contains an optional top-level "diagnostics" object with
+      analyzed_files, lcov_files, matched_files, and
+      source_only / lcov_only as {count, examples[]} (examples capped
+      at 10)
+And   the published schemas (report-v1.json, delta-v2.json) accept the
+      new optional field — existing documents stay valid, no version bump
+```
+
+### Scenario: No --lcov, no diagnostics
+
+```
+Given a complexity-only run (no --lcov)
+When  cargo-crap runs with --format json
+Then  no scope warning is printed
+And   the envelope contains no "diagnostics" object
+```
+
+---
+
+## Implementation Notes
+
+- `merge::MergeResult` already tracks `unmapped_files` (source-only).
+  Add the mirror `lcov_only_files`: coverage-map keys never consumed
+  by either the fast or the slow path of `PathIndex`. Counts derive
+  from these plus the entry set — no new walking.
+- `warn_unmapped` in `main.rs` grows into the scope warning: counts
+  first, then ≤ 10 examples per side with a "… and N more" tail. This
+  intentionally REPLACES today's unbounded per-file listing (the full
+  list moves behind the JSON examples cap; stderr stays readable on
+  1000-file mismatches).
+- Threshold for the escalated wording: `matched_files * 2 <
+  analyzed_files` (i.e. < 50 % of analyzed files matched), zero
+  matches gets its own wording. Values chosen for the warning text
+  only — no behavioural gate hangs off them.
+- JSON: the `diagnostics` object is optional and additive in both
+  envelopes; emitted only when `--lcov` was supplied. Schema files
+  updated in place — an optional field does not invalidate previously
+  published documents, so `report-v1` / `delta-v2` keep their names.
+- Delta note: the baseline side needs no diagnostics of its own — the
+  mismatch is a property of the current run's inputs. The warning
+  printing before the delta output satisfies "visible before
+  presenting the delta" from the issue.
+
+### Non-goals
+
+- No new gate (`--fail-on-mismatch` or similar) — CI wrappers can
+  gate on the JSON counts themselves. Revisit only if requested.
+- No coverage generation, no CI-artifact management (explicitly out
+  of scope in the issue).
+- No change to `--missing` semantics: pessimistic 0 % for unmatched
+  functions remains the default and the right CI behaviour.

--- a/specs/25-repeatable-package-selector.md
+++ b/specs/25-repeatable-package-selector.md
@@ -1,0 +1,146 @@
+# Spec 25 — Repeatable `--package` selector for workspace analysis
+
+**Status:** Proposed (issue #55)
+**Effort:** Medium
+**Module:** `src/main.rs` (CLI, `analyze_sources`, baseline filtering)
+
+## Context
+
+Large workspaces currently choose between one `--path` root and the
+full `--workspace`. Changed-file CI usually already knows which
+packages a PR touches, but has to invoke cargo-crap once per package
+and aggregate reports and exit codes by hand.
+
+This spec adds a cargo-style repeatable selector:
+
+```
+cargo crap -p backend_core -p backend_identity --lcov lcov.info
+```
+
+One invocation, one LCOV parse, one baseline comparison, one report,
+one gate decision — over exactly the selected members.
+
+CLI-only, deliberately no config key: the selection is inherently
+per-run (a changed-file pipeline computes a different set on every
+PR), so the config-first house rule does not apply.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Two selected packages produce one combined report
+
+```
+Given a workspace with members backend_core, backend_identity, frontend
+When  cargo crap -p backend_core -p backend_identity --lcov lcov.info runs
+Then  a single report contains functions from both selected members
+      and none from frontend
+And   JSON entries keep their "crate" attribution
+And   the per-crate rollup lists exactly the two selected members
+```
+
+### Scenario: One selected package matches the single-root equivalent
+
+```
+Given member backend_core rooted at crates/backend_core
+When  cargo crap -p backend_core --lcov lcov.info runs
+Then  the entry set equals cargo crap --path crates/backend_core
+      --lcov lcov.info (modulo the "crate" attribution field)
+```
+
+### Scenario: Unknown package names fail before analysis
+
+```
+Given -p backend_core -p backend_typo
+When  cargo-crap runs
+Then  it exits with the tool-error code (2, spec 23) before any file
+      is analyzed
+And   stderr names the unknown package and lists the available members
+```
+
+### Scenario: Duplicate selections are deduplicated
+
+```
+Given -p backend_core -p backend_core
+When  cargo-crap runs
+Then  backend_core's files are analyzed once and appear once
+```
+
+### Scenario: Selecting a parent package does not recurse into a nested member
+
+```
+Given member parent rooted at crates/parent
+And   member nested rooted at crates/parent/nested
+When  cargo crap -p parent runs
+Then  no function from crates/parent/nested appears in the report
+And   when both are selected, each file is analyzed exactly once and
+      attributed to the deepest member
+```
+
+### Scenario: Gate spans all selected packages
+
+```
+Given a regression in backend_identity and none in backend_core
+When  cargo crap -p backend_core -p backend_identity
+      --baseline base.json --fail-regression runs
+Then  the exit code is 1 (single gate over the combined report)
+```
+
+### Scenario: Baseline subset does not flood `removed`
+
+```
+Given a baseline recorded with --workspace (all members)
+When  the current run selects only backend_core with -p
+Then  baseline entries from unselected members are filtered out before
+      compute_delta (spec 18 semantics — analyzed roots are now the
+      selected members' dirs)
+And   `removed` does not list every function of the unselected members
+```
+
+### Scenario: Flag interactions
+
+```
+Given --workspace and -p together
+Then  clap rejects the combination (usage error, exit 2) —
+      --workspace already means "all members"
+
+Given -p without a reachable `cargo metadata` (not in a cargo project)
+Then  the run exits 2 with the metadata error
+
+Given -p together with --path
+Then  --path is ignored, exactly as it is under --workspace
+```
+
+---
+
+## Implementation Notes
+
+- CLI: `#[arg(short = 'p', long = "package")] packages: Vec<String>`,
+  `conflicts_with = "workspace"`. Cargo's own `-p` semantics are the
+  model.
+- `analyze_sources` grows a third mode: discover members via the
+  existing `workspace_members()`, validate the selection (unknown →
+  `bail!` listing available names, dedupe via a set), then walk each
+  selected member's dir. `members` returned for `assign_crate_names`
+  is the selected subset.
+- **Nested-member exclusion:** when walking a member root, skip any
+  other discovered member's root nested beneath it — the nested
+  member owns its files (analyzed only if itself selected). Note:
+  `--workspace` mode has the same latent double-analysis for nested
+  layouts (a root package whose dir contains member dirs); the
+  exclusion helper should apply to both modes, which also pins
+  "each source file is analyzed once" for `--workspace`.
+- Baseline filtering needs no new code: `BaselineFilter` already keys
+  on the analyzed roots (spec 18); with `-p`, those roots are the
+  selected members' dirs.
+- Default excludes (spec 14) apply per selected root, as in
+  `--workspace` mode.
+- README: document `-p/--package` next to `--workspace`.
+
+### Non-goals
+
+- No git change detection — the caller selects packages (explicit in
+  the issue).
+- No glob/spec matching on package names (`-p 'backend_*'`); exact
+  names only until someone asks.
+- No `packages` config key (see Context).


### PR DESCRIPTION
Proposes three specs for the triaged issues from @Manubi, in intended implementation order:

- **Spec 23 — exit-code contract** (#54, small): `0` = pass, `1` = gate tripped after a complete report, `2` = usage/input/analysis/output error. Follows the grep convention; clap's usage exit 2 becomes part of the contract. Zero-vs-nonzero callers unaffected.
- **Spec 24 — scope-mismatch diagnostics** (#53, medium): counts for analyzed/LCOV/matched files, both-direction stray lists with bounded stderr examples, escalated wording under 50 % overlap, and an optional additive `diagnostics` object in the JSON envelopes (no schema version bump). Replaces today's unbounded unmatched-file listing. Diagnostics only — no score or gate changes.
- **Spec 25 — repeatable `-p`/`--package`** (#55, medium): cargo-style selected-workspace analysis with one LCOV parse, one report, one gate. Unknown names fail before analysis (exit 2 per spec 23); nested member roots are excluded from parent walks — which also fixes the latent double-analysis in `--workspace` mode for nested layouts. CLI-only by design (per-run selection), no config key.

Why three specs, not one: the changes are orthogonal (main-only vs merge+json vs CLI+walk) and will land as separate PRs. Ordering matters only softly — spec 23 first, so specs 24/25's new failure modes are born into the documented error class.

Closes nothing yet — implementation PRs will reference the issues.