### PR TITLE
feat: exit-code contract — 1 for gate trips, 2 for tool errors (spec 23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ the coverage run was scoped to a subset of the workspace. Three policies:
 
 ## Integrating with CI
 
+### Exit codes
+
+The exit code distinguishes a finished CRAP verdict from a broken run,
+so wrappers never need file-size or log-parsing heuristics:
+
+| Code | Meaning                                                                                        |
+|------|------------------------------------------------------------------------------------------------|
+| 0    | Analysis completed; no requested gate tripped.                                                 |
+| 1    | Analysis completed and the report was fully written; `--fail-above` / `--fail-regression` tripped. |
+| 2    | The run did not complete: usage, input, analysis, or output error.                             |
+
 ### Absolute threshold gate
 
 ```yaml

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufWriter, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::time::Duration;
 
 #[derive(Parser, Debug)]
@@ -792,7 +793,21 @@ fn parse_and_load_config() -> Result<(Cli, cargo_crap::config::Config)> {
     Ok((cli, config))
 }
 
-fn main() -> Result<()> {
+/// Exit-code contract (spec 23): 0 = analysis completed and no requested
+/// gate tripped; 1 = analysis completed, report written, a gate tripped;
+/// 2 = the run did not complete (usage, input, analysis, or output error —
+/// clap's own usage exit is also 2).
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            ExitCode::from(2)
+        },
+    }
+}
+
+fn run() -> Result<ExitCode> {
     let (cli, config) = parse_and_load_config()?;
 
     // Merge: CLI values take precedence; config fills in what's missing.
@@ -883,14 +898,15 @@ fn main() -> Result<()> {
     };
     let (has_crappy, has_regression) =
         do_render(&entries, baseline_data.as_deref(), &opts, out_box.as_mut())?;
-    // `std::process::exit` below skips destructors, so the BufWriter around
-    // `--output` must be flushed here or the report file is left empty (#47).
+    // The flush must precede the gate decision: a write failure (e.g.
+    // ENOSPC) is a tool error (exit 2), never a gate verdict over a
+    // truncated report (#47, spec 23).
     out_box.flush().context("flushing output")?;
 
     if (fail_above && has_crappy) || (fail_regression && has_regression) {
-        std::process::exit(1);
+        return Ok(ExitCode::from(1));
     }
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 #[cfg(test)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3276,3 +3276,126 @@ fn cross_root_baseline_matches_all_functions() {
         "no baseline entry may be orphaned by the root remap"
     );
 }
+
+// --- Exit-code contract (spec 23) ---
+
+#[test]
+fn gate_trip_exits_with_code_1_and_complete_report() {
+    // Policy failure is exit 1 exactly — not just "nonzero" — and the
+    // report file is complete before the verdict.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = regression_baseline(&dir);
+    let report_path = dir.path().join("report.json");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--fail-regression")
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&report_path)
+        .assert()
+        .code(1);
+
+    let report = std::fs::read_to_string(&report_path).expect("report file must exist");
+    let json: serde_json::Value =
+        serde_json::from_str(&report).expect("report must be complete valid JSON");
+    assert!(
+        json["entries"]
+            .as_array()
+            .is_some_and(|e| e.iter().any(|x| x["status"] == "regressed")),
+        "report written before the exit-1 verdict must contain the regression"
+    );
+}
+
+#[test]
+fn fail_above_trip_exits_with_code_1() {
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--fail-above")
+        .arg("--threshold")
+        .arg("5")
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn clean_gated_run_exits_with_code_0() {
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--fail-above")
+        .arg("--threshold")
+        .arg("99999")
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn malformed_lcov_exits_with_code_2() {
+    // A malformed record (unparseable DA line) is an input error, not a
+    // gate verdict. Unknown record *types* are still skipped (issue #21) —
+    // this is a syntactically broken line, which must fail loudly.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lcov_path = dir.path().join("garbage.info");
+    std::fs::write(&lcov_path, "this is not lcov data\nDA:abc\n").expect("write garbage");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("parsing LCOV file"));
+}
+
+#[test]
+fn unwritable_output_exits_with_code_2_not_1() {
+    // Even with a tripping --fail-regression, a report that cannot be
+    // produced is a tool error (2), never a gate verdict (1).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = regression_baseline(&dir);
+    let unwritable = dir.path().join("no-such-dir").join("report.json");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--fail-regression")
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&unwritable)
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn nonexistent_path_exits_with_code_2() {
+    cmd()
+        .arg("--path")
+        .arg("does/not/exist")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("path does not exist"));
+}
+
+#[test]
+fn unknown_flag_exits_with_code_2() {
+    // clap's usage exit is part of the documented contract.
+    cmd().arg("--frobnicate").assert().code(2);
+}


### PR DESCRIPTION
Implements spec 23 (proposed in #57) for issue #54.

## Contract

| Code | Meaning |
|------|---------|
| 0 | Analysis completed; no requested gate tripped. |
| 1 | Analysis completed and the report was fully written; `--fail-above` / `--fail-regression` tripped. |
| 2 | The run did not complete: usage, input, analysis, or output error. |

## Changes

- `main()` returns `ExitCode` and delegates to `run() -> Result<ExitCode>`; `Err` prints the anyhow chain (`Error: …` + causes, same text as before) and exits 2. Previously std mapped every `Err` to exit 1, indistinguishable from a gate verdict.
- The gate branch returns `ExitCode::from(1)` instead of `std::process::exit(1)` — destructors now run too, and the #47 flush still precedes the verdict, so an output-write failure (e.g. `ENOSPC`, unwritable path) is exit 2, never a gate verdict over a truncated report.
- clap's usage exit 2 becomes part of the documented contract (unchanged behavior, now pinned by a test).
- README: exit-code table added to the CI section.

## Tests

Seven CLI tests assert exact codes, not just nonzero: gate trip → 1 (with complete report on disk), clean gated run → 0, malformed LCOV → 2, unwritable `--output` under a tripping `--fail-regression` → 2 (not 1), nonexistent `--path` → 2, unknown flag → 2.

Existing callers checking zero vs non-zero are unaffected; all pre-existing tests used `.failure()` and pass unchanged.

## Verification

- `just dev` clean (fmt, clippy, tests, dogfood).
- `just dev-mutants-diff`: 87 mutants on `src/main.rs` — 75 caught, 12 unviable, 0 missed.

Closes #54.