### PR TITLE
feat: source/LCOV scope-mismatch diagnostics (spec 24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ generate types directly from the schema.
 `--baseline` only reads files in this envelope shape; bare-array baselines
 from older runs must be regenerated.
 
+Both envelopes also carry an optional `diagnostics` object whenever `--lcov`
+was supplied: analyzed/LCOV/matched file counts plus bounded example lists
+of files present only on one side. When the analyzed tree and the coverage
+run describe different scopes (the classic cause of a delta full of
+unrelated 0%-coverage entries), a warning with the same numbers is printed
+to stderr before the report, and CI wrappers can gate on the JSON counts.
+
 ### SARIF output
 
 `--format sarif` emits a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)

--- a/schemas/delta-v2.json
+++ b/schemas/delta-v2.json
@@ -24,6 +24,10 @@
       "type": "array",
       "description": "Functions present in the baseline but absent from the current run.",
       "items": { "$ref": "#/definitions/RemovedEntry" }
+    },
+    "diagnostics": {
+      "$ref": "#/definitions/ScopeDiagnostics",
+      "description": "Optional source/LCOV scope diagnostics for the current run (spec 24); absent for complexity-only runs."
     }
   },
   "definitions": {
@@ -84,6 +88,56 @@
           "type": "number",
           "minimum": 1,
           "description": "CRAP score the function had in the baseline."
+        }
+      }
+    },
+    "ScopeDiagnostics": {
+      "type": "object",
+      "description": "Source/LCOV scope overlap (spec 24). Large stray sets mean the analyzed tree and the coverage run describe different scopes.",
+      "required": ["analyzed_files", "lcov_files", "matched_files", "source_only", "lcov_only"],
+      "additionalProperties": false,
+      "properties": {
+        "analyzed_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct source files that produced at least one analyzed function."
+        },
+        "lcov_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct SF records in the LCOV report."
+        },
+        "matched_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Files present on both sides after path matching."
+        },
+        "source_only": {
+          "$ref": "#/definitions/StrayFiles",
+          "description": "Analyzed files with no LCOV match."
+        },
+        "lcov_only": {
+          "$ref": "#/definitions/StrayFiles",
+          "description": "LCOV SF files matched by no analyzed file."
+        }
+      }
+    },
+    "StrayFiles": {
+      "type": "object",
+      "description": "One side's stray files: the true count plus at most 10 sorted example paths.",
+      "required": ["count", "examples"],
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "True number of stray files on this side (not capped)."
+        },
+        "examples": {
+          "type": "array",
+          "maxItems": 10,
+          "items": { "type": "string" },
+          "description": "Sorted example paths, capped at 10."
         }
       }
     }

--- a/schemas/report-v1.json
+++ b/schemas/report-v1.json
@@ -21,6 +21,10 @@
       "type": "array",
       "description": "Per-function CRAP entries, sorted by score descending.",
       "items": { "$ref": "#/definitions/CrapEntry" }
+    },
+    "diagnostics": {
+      "$ref": "#/definitions/ScopeDiagnostics",
+      "description": "Optional source/LCOV scope diagnostics (spec 24); absent for complexity-only runs."
     }
   },
   "definitions": {
@@ -61,6 +65,56 @@
         "crate": {
           "type": "string",
           "description": "Cargo workspace member name. Present only on `--workspace` runs."
+        }
+      }
+    },
+    "ScopeDiagnostics": {
+      "type": "object",
+      "description": "Source/LCOV scope overlap (spec 24). Large stray sets mean the analyzed tree and the coverage run describe different scopes.",
+      "required": ["analyzed_files", "lcov_files", "matched_files", "source_only", "lcov_only"],
+      "additionalProperties": false,
+      "properties": {
+        "analyzed_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct source files that produced at least one analyzed function."
+        },
+        "lcov_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct SF records in the LCOV report."
+        },
+        "matched_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Files present on both sides after path matching."
+        },
+        "source_only": {
+          "$ref": "#/definitions/StrayFiles",
+          "description": "Analyzed files with no LCOV match."
+        },
+        "lcov_only": {
+          "$ref": "#/definitions/StrayFiles",
+          "description": "LCOV SF files matched by no analyzed file."
+        }
+      }
+    },
+    "StrayFiles": {
+      "type": "object",
+      "description": "One side's stray files: the true count plus at most 10 sorted example paths.",
+      "required": ["count", "examples"],
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "True number of stray files on this side (not capped)."
+        },
+        "examples": {
+          "type": "array",
+          "maxItems": 10,
+          "items": { "type": "string" },
+          "description": "Sorted example paths, capped at 10."
         }
       }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
 //! // 4. Render the human-readable table to stdout.
-//! render(&entries, DEFAULT_THRESHOLD, Format::Human, None, &mut io::stdout())?;
+//! render(&entries, DEFAULT_THRESHOLD, Format::Human, None, None, &mut io::stdout())?;
 //!
 //! # Ok::<(), anyhow::Error>(())
 //! ```
@@ -133,7 +133,7 @@
 //!
 //! // Exit non-zero if any function regressed.
 //! if report.regression_count() > 0 {
-//!     render_delta(&report, 30.0, Format::Human, None, false, &mut io::stdout())?;
+//!     render_delta(&report, 30.0, Format::Human, None, false, None, &mut io::stdout())?;
 //!     std::process::exit(1);
 //! }
 //! # Ok::<(), anyhow::Error>(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use cargo_crap::{
     complexity,
     coverage::{self, FileCoverage},
     delta::{compute_delta, load_baseline},
-    merge::{MissingCoveragePolicy, SortOrder, merge, sort_entries},
+    merge::{MissingCoveragePolicy, ScopeDiagnostics, SortOrder, merge, sort_entries},
     report::{
         Format, SourceLinks, crappy_count, render, render_delta, render_delta_summary,
         render_summary, set_color_enabled,
@@ -621,23 +621,78 @@ fn workspace_members() -> Result<Vec<WorkspaceMember>> {
     Ok(members)
 }
 
-/// Emit a stderr warning listing source files with no LCOV match.
+/// Lead line of the scope-mismatch warning, picked by overlap severity
+/// (spec 24): zero matches and sub-50% overlap get an explicit
+/// different-scopes verdict; smaller mismatches keep the neutral wording.
+fn scope_warning_lead(diag: &ScopeDiagnostics) -> String {
+    if diag.matched_files == 0 {
+        format!(
+            "warning: no overlap between the analyzed sources and the LCOV report \
+             ({} analyzed, {} in LCOV, 0 matched) — the analyzed tree and the \
+             coverage run describe different scopes",
+            diag.analyzed_files, diag.lcov_files,
+        )
+    } else if diag.matched_files * 2 < diag.analyzed_files {
+        format!(
+            "warning: only {} of {} analyzed files match the LCOV report — the \
+             analyzed tree and the coverage run likely describe different scopes",
+            diag.matched_files, diag.analyzed_files,
+        )
+    } else {
+        format!(
+            "warning: source/LCOV scope mismatch ({} analyzed, {} in LCOV, {} matched) \
+             — verify your --lcov path or coverage tool configuration",
+            diag.analyzed_files, diag.lcov_files, diag.matched_files,
+        )
+    }
+}
+
+/// Detail lines for one stray side: `count` + `label` header, then the
+/// bounded examples, then a `... and N more` tail when the cap truncated.
+fn stray_lines(
+    label: &str,
+    strays: &cargo_crap::merge::StrayFiles,
+) -> Vec<String> {
+    if strays.count == 0 {
+        return Vec::new();
+    }
+    let mut lines = vec![format!("  {} {label}:", strays.count)];
+    lines.extend(
+        strays
+            .examples
+            .iter()
+            .map(|f| format!("    {}", f.display())),
+    );
+    if strays.count > strays.examples.len() {
+        lines.push(format!(
+            "    ... and {} more",
+            strays.count - strays.examples.len()
+        ));
+    }
+    lines
+}
+
+/// Emit the scope-mismatch warning (spec 24) to stderr, ahead of the report.
 ///
-/// `unmapped_files` is empty when no `--lcov` was given (merge guarantees this),
-/// so the call is always safe and the guard lives here rather than at the call site.
-fn warn_unmapped(files: &[std::path::PathBuf]) {
-    if files.is_empty() {
+/// Silent when there are no diagnostics (no `--lcov`) or when both stray
+/// sides are empty (scopes match exactly).
+fn warn_scope_mismatch(diag: Option<&ScopeDiagnostics>) {
+    let Some(d) = diag else { return };
+    if d.source_only.count == 0 && d.lcov_only.count == 0 {
         return;
     }
-    let n = files.len();
-    eprintln!(
-        "warning: {} source file{} had no matching entry in the LCOV report \
-         — verify your --lcov path or coverage tool configuration:",
-        n,
-        if n == 1 { "" } else { "s" },
-    );
-    for f in files {
-        eprintln!("  {}", f.display());
+    eprintln!("{}", scope_warning_lead(d));
+    let details = stray_lines(
+        "analyzed source file(s) had no matching entry in the LCOV report",
+        &d.source_only,
+    )
+    .into_iter()
+    .chain(stray_lines(
+        "LCOV file(s) matched no analyzed source file",
+        &d.lcov_only,
+    ));
+    for line in details {
+        eprintln!("{line}");
     }
 }
 
@@ -698,6 +753,8 @@ struct RenderOpts<'a> {
     /// Final entry ordering (spec 17). Applied to the `DeltaReport` so
     /// `removed` ordering is deterministic too.
     sort: SortOrder,
+    /// Source/LCOV scope diagnostics (spec 24); embedded in JSON envelopes.
+    diagnostics: Option<&'a ScopeDiagnostics>,
 }
 
 /// Load the `--baseline` file (if any) and filter it through the current
@@ -748,6 +805,7 @@ fn do_render(
                 opts.format,
                 opts.links,
                 opts.show_unchanged,
+                opts.diagnostics,
                 out,
             )?;
         }
@@ -757,7 +815,14 @@ fn do_render(
         if opts.summary {
             render_summary(entries, opts.threshold, out)?;
         } else {
-            render(entries, opts.threshold, opts.format, opts.links, out)?;
+            render(
+                entries,
+                opts.threshold,
+                opts.format,
+                opts.links,
+                opts.diagnostics,
+                out,
+            )?;
         }
         Ok((has_crappy, false))
     }
@@ -856,7 +921,8 @@ fn run() -> Result<ExitCode> {
 
     // --- Merge + filters ---
     let merge_result = merge(fns, coverage, missing_policy);
-    warn_unmapped(&merge_result.unmapped_files);
+    let diagnostics = merge_result.diagnostics;
+    warn_scope_mismatch(diagnostics.as_ref());
     let mut entries = merge_result.entries;
     assign_crate_names(&mut entries, &members);
     apply_filters(
@@ -895,6 +961,7 @@ fn run() -> Result<ExitCode> {
         links: links.as_ref(),
         show_unchanged,
         sort: sort_order,
+        diagnostics: diagnostics.as_ref(),
     };
     let (has_crappy, has_regression) =
         do_render(&entries, baseline_data.as_deref(), &opts, out_box.as_mut())?;
@@ -912,6 +979,104 @@ fn run() -> Result<ExitCode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cargo_crap::merge::StrayFiles;
+
+    fn diag(
+        analyzed: usize,
+        lcov: usize,
+        matched: usize,
+    ) -> ScopeDiagnostics {
+        ScopeDiagnostics {
+            analyzed_files: analyzed,
+            lcov_files: lcov,
+            matched_files: matched,
+            source_only: StrayFiles {
+                count: analyzed - matched,
+                examples: Vec::new(),
+            },
+            lcov_only: StrayFiles {
+                count: lcov - matched,
+                examples: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn scope_warning_lead_zero_overlap_gets_strongest_wording() {
+        let lead = scope_warning_lead(&diag(3, 5, 0));
+        assert!(lead.contains("no overlap"), "got: {lead}");
+        assert!(lead.contains("3 analyzed"), "got: {lead}");
+        assert!(lead.contains("5 in LCOV"), "got: {lead}");
+    }
+
+    #[test]
+    fn scope_warning_lead_below_half_escalates() {
+        let lead = scope_warning_lead(&diag(40, 20, 15));
+        assert!(lead.contains("only 15 of 40"), "got: {lead}");
+        assert!(
+            lead.contains("likely describe different scopes"),
+            "got: {lead}"
+        );
+    }
+
+    #[test]
+    fn scope_warning_lead_exactly_half_stays_neutral() {
+        // 2*matched == analyzed is NOT "fewer than half" — the escalation
+        // must not fire (kills < → <= on the *2 comparison).
+        let lead = scope_warning_lead(&diag(4, 4, 2));
+        assert!(!lead.contains("only"), "got: {lead}");
+        assert!(
+            lead.contains("4 analyzed, 4 in LCOV, 2 matched"),
+            "got: {lead}"
+        );
+    }
+
+    #[test]
+    fn scope_warning_lead_majority_overlap_stays_neutral() {
+        let lead = scope_warning_lead(&diag(10, 12, 9));
+        assert!(
+            lead.contains("10 analyzed, 12 in LCOV, 9 matched"),
+            "got: {lead}"
+        );
+        assert!(lead.contains("verify your --lcov path"), "got: {lead}");
+    }
+
+    #[test]
+    fn stray_lines_empty_side_produces_nothing() {
+        let s = StrayFiles {
+            count: 0,
+            examples: Vec::new(),
+        };
+        assert!(stray_lines("label", &s).is_empty());
+    }
+
+    #[test]
+    fn stray_lines_no_tail_when_examples_cover_the_count() {
+        let s = StrayFiles {
+            count: 2,
+            examples: vec![PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")],
+        };
+        let lines = stray_lines("file(s) missing", &s);
+        assert_eq!(
+            lines,
+            vec![
+                "  2 file(s) missing:".to_string(),
+                "    src/a.rs".to_string(),
+                "    src/b.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn stray_lines_tail_counts_the_truncated_remainder() {
+        let s = StrayFiles {
+            count: 13,
+            examples: (0..10).map(|i| PathBuf::from(format!("f{i}.rs"))).collect(),
+        };
+        let lines = stray_lines("stray", &s);
+        assert_eq!(lines.len(), 12, "header + 10 examples + tail");
+        assert_eq!(lines.last().unwrap(), "    ... and 3 more");
+    }
 
     #[test]
     fn resolve_color_truth_table() {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -229,9 +229,19 @@ pub fn merge(
             .filter(|f| !mapped_files.contains(*f))
             .cloned()
             .collect();
+        // Canonical forms of the consumed absolute keys. An unconsumed key
+        // aliasing a consumed one (symlinked checkout root, /tmp vs
+        // /private/tmp, `lcov -a`-merged runs) describes the same real file
+        // and must not be reported as a stray: only one alias survives
+        // `PathIndex::build`'s canonical-keyed map, but all of them matched.
+        let used_canonical: HashSet<PathBuf> = used_lcov_keys
+            .iter()
+            .filter(|k| k.is_absolute())
+            .filter_map(|k| k.canonicalize().ok())
+            .collect();
         let lcov_only: Vec<PathBuf> = coverage
             .keys()
-            .filter(|k| !used_lcov_keys.contains(*k))
+            .filter(|k| !used_lcov_keys.contains(*k) && !aliases_used(k, &used_canonical))
             .cloned()
             .collect();
         ScopeDiagnostics {
@@ -247,6 +257,21 @@ pub fn merge(
         entries,
         diagnostics,
     }
+}
+
+/// True when `key` is an absolute path whose canonical form matches a
+/// consumed key's canonical form — the same real file reached through a
+/// different spelling. Relative keys never alias: canonicalizing them would
+/// resolve against the CWD, which the path-matching invariant forbids.
+fn aliases_used(
+    key: &Path,
+    used_canonical: &HashSet<PathBuf>,
+) -> bool {
+    if !key.is_absolute() {
+        return false;
+    }
+    key.canonicalize()
+        .is_ok_and(|c| used_canonical.contains(&c))
 }
 
 /// A path lookup index that handles absolute-vs-relative mismatches between
@@ -532,6 +557,76 @@ mod tests {
             ],
             "lcov_only examples must be sorted"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_alias_of_a_consumed_key_is_not_lcov_only() {
+        // Two absolute SF records spelling the same real file (one through a
+        // symlink) collide on PathIndex's canonical key; only one raw key can
+        // be consumed. The unconsumed alias still described a matched file
+        // and must not be reported as a stray (no spurious scope warning on
+        // a perfectly matched scope).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("a.rs");
+        std::fs::write(&real, "pub fn f() {}\n").expect("write");
+        let link = dir.path().join("link.rs");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let mut cov_map = HashMap::new();
+        cov_map.insert(real.clone(), cov_with(&[(1, 1)]));
+        cov_map.insert(link, cov_with(&[(1, 1)]));
+
+        let complexity = vec![FunctionComplexity {
+            file: real,
+            name: "f".into(),
+            start_line: 1,
+            end_line: 1,
+            cyclomatic: 1.0,
+        }];
+
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        let diag = result.diagnostics.expect("diagnostics present");
+        assert_eq!(diag.matched_files, 1);
+        assert_eq!(
+            diag.lcov_only.count, 0,
+            "an alias of a consumed key is not a stray"
+        );
+        assert_eq!(diag.source_only.count, 0);
+    }
+
+    #[test]
+    fn relative_key_is_never_treated_as_an_alias() {
+        // src/merge.rs exists relative to the crate root (the unit-test CWD).
+        // The absolute spelling is consumed via the fast path; the relative
+        // spelling must still be reported as lcov_only — resolving it against
+        // the CWD to discover the aliasing would violate the invariant that
+        // relative LCOV paths are never canonicalized (kills dropping the
+        // is_absolute guard in aliases_used).
+        let abs = PathBuf::from("src/merge.rs")
+            .canonicalize()
+            .expect("crate-root CWD");
+
+        let mut cov_map = HashMap::new();
+        cov_map.insert(abs.clone(), cov_with(&[(1, 1)]));
+        cov_map.insert(PathBuf::from("src/merge.rs"), cov_with(&[(1, 1)]));
+
+        let complexity = vec![FunctionComplexity {
+            file: abs,
+            name: "f".into(),
+            start_line: 1,
+            end_line: 1,
+            cyclomatic: 1.0,
+        }];
+
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        let diag = result.diagnostics.expect("diagnostics present");
+        assert_eq!(diag.matched_files, 1);
+        assert_eq!(
+            diag.lcov_only.count, 1,
+            "the relative spelling stays a stray — CWD resolution is forbidden"
+        );
+        assert_eq!(diag.lcov_only.examples, vec![PathBuf::from("src/merge.rs")]);
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -109,15 +109,56 @@ pub enum MissingCoveragePolicy {
     Skip,
 }
 
-/// Output of [`merge`]: the scored entries plus any source files that had no
-/// matching entry in the LCOV report.
+/// Cap on example paths carried per stray side of [`ScopeDiagnostics`].
+/// `count` always holds the true total; only the examples are bounded, so
+/// a 1000-file mismatch stays readable on stderr and in JSON (spec 24).
+pub const SCOPE_EXAMPLE_CAP: usize = 10;
+
+/// One side's stray files: the true count plus at most
+/// [`SCOPE_EXAMPLE_CAP`] example paths, sorted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StrayFiles {
+    pub count: usize,
+    pub examples: Vec<PathBuf>,
+}
+
+impl StrayFiles {
+    fn new(mut files: Vec<PathBuf>) -> Self {
+        files.sort();
+        let count = files.len();
+        files.truncate(SCOPE_EXAMPLE_CAP);
+        Self {
+            count,
+            examples: files,
+        }
+    }
+}
+
+/// Source/LCOV scope diagnostics (spec 24): how well the analyzed source
+/// tree and the LCOV report overlap. A large stray set on either side means
+/// the two inputs describe different scopes — the classic cause of a delta
+/// full of unrelated 0%-coverage entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeDiagnostics {
+    /// Distinct source files that produced at least one analyzed function.
+    pub analyzed_files: usize,
+    /// Distinct `SF` records in the LCOV report.
+    pub lcov_files: usize,
+    /// Files present on both sides after path matching.
+    pub matched_files: usize,
+    /// Analyzed files with no LCOV match.
+    pub source_only: StrayFiles,
+    /// LCOV `SF` files matched by no analyzed file.
+    pub lcov_only: StrayFiles,
+}
+
+/// Output of [`merge`]: the scored entries plus scope diagnostics.
 pub struct MergeResult {
     /// CRAP entries sorted by score descending.
     pub entries: Vec<CrapEntry>,
-    /// Source files for which no coverage data could be found in the LCOV
-    /// report. Only populated when a non-empty coverage map was provided.
-    /// Non-empty here is a strong signal of a path-matching problem.
-    pub unmapped_files: Vec<PathBuf>,
+    /// Source/LCOV overlap diagnostics. `Some` exactly when a non-empty
+    /// coverage map was provided; `None` for complexity-only runs.
+    pub diagnostics: Option<ScopeDiagnostics>,
 }
 
 /// Merge complexity and coverage data into a sorted [`MergeResult`]
@@ -137,17 +178,21 @@ pub fn merge(
 
     let mut mapped_files: HashSet<PathBuf> = HashSet::new();
     let mut seen_files: HashSet<PathBuf> = HashSet::new();
+    // Raw LCOV keys consumed by at least one lookup — the complement is the
+    // lcov_only side of the scope diagnostics.
+    let mut used_lcov_keys: HashSet<PathBuf> = HashSet::new();
 
     let mut entries: Vec<CrapEntry> = complexity
         .into_iter()
         .filter_map(|fc| {
-            let cov = index
-                .lookup(&fc.file)
-                .map(|cov_file| cov_file.coverage_in_span(fc.start_line, fc.end_line));
+            let hit = index.lookup(&fc.file);
+            let cov =
+                hit.map(|(_, cov_file)| cov_file.coverage_in_span(fc.start_line, fc.end_line));
 
             if has_coverage {
-                if cov.is_some() {
+                if let Some((raw_key, _)) = hit {
                     mapped_files.insert(fc.file.clone());
+                    used_lcov_keys.insert(raw_key.to_path_buf());
                 }
                 seen_files.insert(fc.file.clone());
             }
@@ -178,15 +223,29 @@ pub fn merge(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let mut unmapped_files: Vec<PathBuf> = seen_files
-        .into_iter()
-        .filter(|f| !mapped_files.contains(f))
-        .collect();
-    unmapped_files.sort();
+    let diagnostics = has_coverage.then(|| {
+        let source_only: Vec<PathBuf> = seen_files
+            .iter()
+            .filter(|f| !mapped_files.contains(*f))
+            .cloned()
+            .collect();
+        let lcov_only: Vec<PathBuf> = coverage
+            .keys()
+            .filter(|k| !used_lcov_keys.contains(*k))
+            .cloned()
+            .collect();
+        ScopeDiagnostics {
+            analyzed_files: seen_files.len(),
+            lcov_files: coverage.len(),
+            matched_files: mapped_files.len(),
+            source_only: StrayFiles::new(source_only),
+            lcov_only: StrayFiles::new(lcov_only),
+        }
+    });
 
     MergeResult {
         entries,
-        unmapped_files,
+        diagnostics,
     }
 }
 
@@ -194,8 +253,10 @@ pub fn merge(
 /// the complexity pass (which has whatever was on the command line) and the
 /// coverage file (which has whatever the coverage tool decided to write).
 struct PathIndex<'a> {
-    /// Canonicalized absolute paths → coverage data. Fast path.
-    by_absolute: HashMap<PathBuf, &'a FileCoverage>,
+    /// Canonicalized absolute paths → (raw LCOV key, coverage data). Fast
+    /// path. The raw key is carried so callers can track which LCOV records
+    /// were consumed (scope diagnostics, spec 24).
+    by_absolute: HashMap<PathBuf, (&'a Path, &'a FileCoverage)>,
     /// Original (possibly relative) paths kept for suffix matching. We keep
     /// them as `(full_path, coverage)` so we can suffix-compare cheaply.
     by_relative: Vec<(PathBuf, &'a FileCoverage)>,
@@ -220,7 +281,7 @@ impl<'a> PathIndex<'a> {
             if raw_path.is_absolute() {
                 match raw_path.canonicalize() {
                     Ok(abs) => {
-                        by_absolute.insert(abs, cov);
+                        by_absolute.insert(abs, (raw_path.as_path(), cov));
                     },
                     Err(_) => {
                         // Absolute but non-existent (e.g., coverage was
@@ -240,15 +301,17 @@ impl<'a> PathIndex<'a> {
         }
     }
 
+    /// Find coverage for `query`, returning the raw LCOV key it bound to
+    /// alongside the data (the key feeds scope diagnostics).
     fn lookup(
         &self,
         query: &Path,
-    ) -> Option<&'a FileCoverage> {
+    ) -> Option<(&Path, &'a FileCoverage)> {
         // Fast path: direct canonical match.
         if let Ok(abs) = query.canonicalize()
-            && let Some(cov) = self.by_absolute.get(&abs)
+            && let Some(&(raw, cov)) = self.by_absolute.get(&abs)
         {
-            return Some(*cov);
+            return Some((raw, cov));
         }
 
         // Slow path: suffix match. A coverage path `src/foo.rs` matches a
@@ -256,7 +319,7 @@ impl<'a> PathIndex<'a> {
         // component-wise suffix of the latter.
         for (rel, cov) in &self.by_relative {
             if path_has_suffix(query, rel) {
-                return Some(*cov);
+                return Some((rel.as_path(), cov));
             }
         }
 
@@ -428,10 +491,102 @@ mod tests {
         ];
 
         let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        let diag = result.diagnostics.expect("lcov provided → diagnostics");
+        assert_eq!(diag.analyzed_files, 2);
+        assert_eq!(diag.lcov_files, 1);
+        assert_eq!(diag.matched_files, 1);
+        assert_eq!(diag.source_only.count, 1);
         assert_eq!(
-            result.unmapped_files,
+            diag.source_only.examples,
             vec![PathBuf::from("/project/src/bar.rs")]
         );
+        assert_eq!(diag.lcov_only.count, 0, "the only LCOV entry was consumed");
+    }
+
+    #[test]
+    fn lcov_only_files_are_reported() {
+        // The mirror case: LCOV mentions files the analysis never saw.
+        let mut cov_map = HashMap::new();
+        cov_map.insert(PathBuf::from("src/foo.rs"), cov_with(&[(1, 1)]));
+        cov_map.insert(PathBuf::from("src/phantom_a.rs"), cov_with(&[(1, 1)]));
+        cov_map.insert(PathBuf::from("src/phantom_b.rs"), cov_with(&[(1, 1)]));
+
+        let complexity = vec![FunctionComplexity {
+            file: PathBuf::from("/project/src/foo.rs"),
+            name: "matched".into(),
+            start_line: 1,
+            end_line: 3,
+            cyclomatic: 1.0,
+        }];
+
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        let diag = result.diagnostics.expect("diagnostics present");
+        assert_eq!(diag.lcov_files, 3);
+        assert_eq!(diag.matched_files, 1);
+        assert_eq!(diag.lcov_only.count, 2);
+        assert_eq!(
+            diag.lcov_only.examples,
+            vec![
+                PathBuf::from("src/phantom_a.rs"),
+                PathBuf::from("src/phantom_b.rs")
+            ],
+            "lcov_only examples must be sorted"
+        );
+    }
+
+    #[test]
+    fn shared_lcov_entry_consumed_by_multiple_files_is_not_lcov_only() {
+        // Two analyzed files suffix-matching the same relative LCOV key
+        // consume it once — it must not surface as lcov_only.
+        let mut cov_map = HashMap::new();
+        cov_map.insert(PathBuf::from("src/lib.rs"), cov_with(&[(1, 1)]));
+
+        let complexity = vec![
+            FunctionComplexity {
+                file: PathBuf::from("/a/src/lib.rs"),
+                name: "one".into(),
+                start_line: 1,
+                end_line: 3,
+                cyclomatic: 1.0,
+            },
+            FunctionComplexity {
+                file: PathBuf::from("/b/src/lib.rs"),
+                name: "two".into(),
+                start_line: 1,
+                end_line: 3,
+                cyclomatic: 1.0,
+            },
+        ];
+
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        let diag = result.diagnostics.expect("diagnostics present");
+        assert_eq!(diag.matched_files, 2);
+        assert_eq!(diag.lcov_only.count, 0);
+    }
+
+    #[test]
+    fn stray_examples_are_capped_but_count_is_exact() {
+        let files: Vec<PathBuf> = (0..SCOPE_EXAMPLE_CAP + 3)
+            .map(|i| PathBuf::from(format!("src/f{i:02}.rs")))
+            .collect();
+        let strays = StrayFiles::new(files);
+        assert_eq!(strays.count, SCOPE_EXAMPLE_CAP + 3);
+        assert_eq!(strays.examples.len(), SCOPE_EXAMPLE_CAP);
+        assert_eq!(
+            strays.examples[0],
+            PathBuf::from("src/f00.rs"),
+            "examples are the sorted head, not an arbitrary subset"
+        );
+    }
+
+    #[test]
+    fn stray_examples_not_truncated_at_or_below_cap() {
+        let files: Vec<PathBuf> = (0..SCOPE_EXAMPLE_CAP)
+            .map(|i| PathBuf::from(format!("src/f{i:02}.rs")))
+            .collect();
+        let strays = StrayFiles::new(files);
+        assert_eq!(strays.count, SCOPE_EXAMPLE_CAP);
+        assert_eq!(strays.examples.len(), SCOPE_EXAMPLE_CAP);
     }
 
     // --- SortOrder / sort_entries (spec 17) --------------------------------
@@ -517,7 +672,7 @@ mod tests {
     }
 
     #[test]
-    fn no_unmapped_files_when_no_lcov_provided() {
+    fn no_diagnostics_when_no_lcov_provided() {
         let complexity = vec![FunctionComplexity {
             file: PathBuf::from("src/foo.rs"),
             name: "foo".into(),
@@ -531,8 +686,8 @@ mod tests {
             MissingCoveragePolicy::Pessimistic,
         );
         assert!(
-            result.unmapped_files.is_empty(),
-            "no lcov → no unmapped warnings"
+            result.diagnostics.is_none(),
+            "no lcov → no scope diagnostics, no warnings"
         );
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -18,7 +18,7 @@
 //! links, per-crate rollups) live in [`types`], [`links`], and [`per_crate`].
 
 use crate::delta::DeltaReport;
-use crate::merge::CrapEntry;
+use crate::merge::{CrapEntry, ScopeDiagnostics};
 use crate::score::Severity;
 use anyhow::{Result, bail};
 use std::io::Write;
@@ -83,15 +83,19 @@ pub enum Format {
 /// For `Format::Human` we emit a table and a summary line. The summary uses
 /// stderr-style coloring if the output is a TTY; `owo-colors` no-ops when
 /// it's not.
+///
+/// `diagnostics` (spec 24) is embedded in the JSON envelope only; every
+/// other format reports scope mismatches via the CLI's stderr warning.
 pub fn render(
     entries: &[CrapEntry],
     threshold: f64,
     format: Format,
     links: Option<&SourceLinks>,
+    diagnostics: Option<&ScopeDiagnostics>,
     out: &mut dyn Write,
 ) -> Result<()> {
     match format {
-        Format::Json => json::render_json(entries, out),
+        Format::Json => json::render_json(entries, diagnostics, out),
         Format::Human => human::render_human(entries, threshold, out),
         Format::GitHub => github::render_github(entries, threshold, out),
         Format::Markdown => markdown::render_markdown(entries, threshold, links, out),
@@ -116,10 +120,11 @@ pub fn render_delta(
     format: Format,
     links: Option<&SourceLinks>,
     show_unchanged: bool,
+    diagnostics: Option<&ScopeDiagnostics>,
     out: &mut dyn Write,
 ) -> Result<()> {
     match format {
-        Format::Json => json::render_delta_json(report, out),
+        Format::Json => json::render_delta_json(report, diagnostics, out),
         Format::Human => human::render_delta_human(report, threshold, show_unchanged, out),
         Format::GitHub => github::render_delta_github(report, threshold, out),
         Format::Markdown => {

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -129,7 +129,7 @@ mod tests {
     fn github_format_emits_warning_for_crappy_function() {
         // Kills: missing the crappy-only guard (`entry.crap > threshold`).
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::GitHub, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("::warning"),
@@ -146,7 +146,7 @@ mod tests {
     fn github_format_clean_function_produces_no_annotation() {
         // Kills: emitting annotations for all functions regardless of threshold.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::GitHub, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         // "clean" (crap=1.0) is well below threshold=30 and must be silent.
         assert!(
@@ -169,7 +169,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::GitHub, None, &mut buf).unwrap();
+        render(&all_clean, 30.0, Format::GitHub, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.is_empty(),
@@ -190,7 +190,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::GitHub, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::GitHub, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("line=42"),

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn human_output_mentions_every_function() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("clean"));
         assert!(s.contains("crappy"));
@@ -324,7 +324,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&all_clean, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains('✓'),
@@ -344,7 +344,7 @@ mod tests {
         // Note: ✓ appears in the row icon for the clean function, so we check
         // the summary count rather than the absence of ✓ in the full output.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('✗'), "output must show ✗ for crappy functions");
         assert!(s.contains("1/2"), "summary must report 1 out of 2 crappy");
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn empty_entries_prints_no_functions_found() {
         let mut buf = Vec::new();
-        render(&[], 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&[], 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("No functions found."));
     }
@@ -371,7 +371,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('—'), "None coverage must render as —");
     }
@@ -389,7 +389,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("44.4"), "Some(44.4) must render as 44.4");
     }
@@ -418,7 +418,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&both_crappy, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&both_crappy, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("2/2"), "both functions crappy, must report 2/2");
     }
@@ -438,7 +438,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('▲'), "moderate score must show ▲");
         assert!(!s.contains('✗'), "moderate score must not show ✗");
@@ -448,7 +448,7 @@ mod tests {
     fn render_human_includes_per_crate_section_when_workspace() {
         let entries = vec![entry(Some("alpha"), "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("Per-crate summary:"),
@@ -461,7 +461,7 @@ mod tests {
     fn render_human_omits_per_crate_section_when_no_workspace_data() {
         let entries = vec![entry(None, "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             !s.contains("Per-crate summary"),

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -5,7 +5,7 @@
 //! input as well — `delta::load_baseline` deserializes the same struct.
 
 use crate::delta::{DeltaEntry, DeltaReport};
-use crate::merge::CrapEntry;
+use crate::merge::{CrapEntry, ScopeDiagnostics};
 use anyhow::Result;
 use std::io::Write;
 
@@ -46,16 +46,23 @@ pub struct Envelope {
     pub schema: Option<String>,
     pub version: String,
     pub entries: Vec<CrapEntry>,
+    /// Source/LCOV scope diagnostics (spec 24). Present only when the run
+    /// had an `--lcov` input; ignored when the envelope is read back as a
+    /// `--baseline` (the mismatch is a property of the producing run).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<ScopeDiagnostics>,
 }
 
 pub(crate) fn render_json(
     entries: &[CrapEntry],
+    diagnostics: Option<&ScopeDiagnostics>,
     out: &mut dyn Write,
 ) -> Result<()> {
     let envelope = Envelope {
         schema: Some(REPORT_SCHEMA_URL.to_string()),
         version: SCHEMA_VERSION.to_string(),
         entries: entries.to_vec(),
+        diagnostics: diagnostics.cloned(),
     };
     serde_json::to_writer_pretty(&mut *out, &envelope)?;
     out.write_all(b"\n")?;
@@ -64,6 +71,7 @@ pub(crate) fn render_json(
 
 pub(crate) fn render_delta_json(
     report: &DeltaReport,
+    diagnostics: Option<&ScopeDiagnostics>,
     out: &mut dyn Write,
 ) -> Result<()> {
     #[derive(serde::Serialize)]
@@ -73,6 +81,8 @@ pub(crate) fn render_delta_json(
         version: &'static str,
         entries: &'a [DeltaEntry],
         removed: &'a [crate::delta::RemovedEntry],
+        #[serde(skip_serializing_if = "Option::is_none")]
+        diagnostics: Option<&'a ScopeDiagnostics>,
     }
     serde_json::to_writer_pretty(
         &mut *out,
@@ -81,6 +91,7 @@ pub(crate) fn render_delta_json(
             version: SCHEMA_VERSION,
             entries: &report.entries,
             removed: &report.removed,
+            diagnostics,
         },
     )?;
     out.write_all(b"\n")?;
@@ -97,7 +108,7 @@ mod tests {
     #[test]
     fn json_output_is_envelope_with_version_and_entries() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Json, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Json, None, None, &mut buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert!(parsed.is_object(), "JSON output must be an envelope object");
         assert_eq!(
@@ -116,6 +127,45 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_embedded_when_present_and_absent_otherwise() {
+        use crate::merge::StrayFiles;
+        let diag = ScopeDiagnostics {
+            analyzed_files: 4,
+            lcov_files: 3,
+            matched_files: 2,
+            source_only: StrayFiles {
+                count: 2,
+                examples: vec![PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")],
+            },
+            lcov_only: StrayFiles {
+                count: 1,
+                examples: vec![PathBuf::from("src/gone.rs")],
+            },
+        };
+
+        let mut buf = Vec::new();
+        render(&sample(), 30.0, Format::Json, None, Some(&diag), &mut buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(parsed["diagnostics"]["analyzed_files"], 4);
+        assert_eq!(parsed["diagnostics"]["lcov_files"], 3);
+        assert_eq!(parsed["diagnostics"]["matched_files"], 2);
+        assert_eq!(parsed["diagnostics"]["source_only"]["count"], 2);
+        assert_eq!(
+            parsed["diagnostics"]["source_only"]["examples"][0],
+            "src/a.rs"
+        );
+        assert_eq!(parsed["diagnostics"]["lcov_only"]["count"], 1);
+
+        let mut buf = Vec::new();
+        render(&sample(), 30.0, Format::Json, None, None, &mut buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(
+            parsed.get("diagnostics").is_none(),
+            "no diagnostics → no key in the envelope"
+        );
+    }
+
+    #[test]
     fn json_format_unaffected_by_links() {
         use super::super::SourceLinks;
         let entries = vec![CrapEntry {
@@ -129,7 +179,7 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Json, Some(&links), &mut buf).unwrap();
+        render(&entries, 30.0, Format::Json, Some(&links), None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             !s.contains("](https://"),

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -264,7 +264,15 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "main".into());
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Markdown, Some(&links), &mut buf).unwrap();
+        render(
+            &entries,
+            30.0,
+            Format::Markdown,
+            Some(&links),
+            None,
+            &mut buf,
+        )
+        .unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("[`foo`](https://github.com/o/r/blob/main/src/a.rs#L7)"),

--- a/src/report/pr_comment.rs
+++ b/src/report/pr_comment.rs
@@ -1066,7 +1066,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.starts_with("<!-- cargo-crap-report -->"));
     }
@@ -1083,7 +1083,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("## ✅ No CRAP threshold violations"));
     }
@@ -1145,7 +1145,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
 
         // Only `above` must appear in the table; the headline still shows it.
@@ -1175,7 +1175,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, &mut buf).unwrap();
+        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("`very_crappy`"),
@@ -1478,7 +1478,15 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "abc".into());
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, Some(&links), &mut buf).unwrap();
+        render(
+            &entries,
+            30.0,
+            Format::PrComment,
+            Some(&links),
+            None,
+            &mut buf,
+        )
+        .unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("[`very_crappy`](https://github.com/o/r/blob/abc/src/a.rs#L42)"),

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -200,7 +200,7 @@ mod tests {
 
     fn render_to_value(threshold: f64) -> serde_json::Value {
         let mut buf = Vec::new();
-        render(&sample(), threshold, Format::Sarif, None, &mut buf).unwrap();
+        render(&sample(), threshold, Format::Sarif, None, None, &mut buf).unwrap();
         serde_json::from_slice(&buf).expect("output must be valid JSON")
     }
 
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn empty_entries_produce_valid_sarif_with_empty_results() {
         let mut buf = Vec::new();
-        render(&[], 30.0, Format::Sarif, None, &mut buf).unwrap();
+        render(&[], 30.0, Format::Sarif, None, None, &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["version"].as_str(), Some(SARIF_VERSION));
         let results = v["runs"][0]["results"]
@@ -306,7 +306,7 @@ mod tests {
             removed: Vec::new(),
         };
         let mut buf = Vec::new();
-        let err = render_delta(&report, 30.0, Format::Sarif, None, false, &mut buf)
+        let err = render_delta(&report, 30.0, Format::Sarif, None, false, None, &mut buf)
             .expect_err("delta + sarif must fail");
         let msg = err.to_string();
         assert!(

--- a/src/report/shields.rs
+++ b/src/report/shields.rs
@@ -145,7 +145,7 @@ mod tests {
     fn render_counts_entries_above_threshold() {
         // sample() has one entry above 30 (CRAP 110) and one below (CRAP 1).
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Shields, None, &mut buf).unwrap();
+        render(&sample(), 30.0, Format::Shields, None, None, &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("1 crappy"));
         assert_eq!(v["color"].as_str(), Some("yellow"));
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn render_with_high_threshold_is_passing() {
         let mut buf = Vec::new();
-        render(&sample(), 200.0, Format::Shields, None, &mut buf).unwrap();
+        render(&sample(), 200.0, Format::Shields, None, None, &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("passing"));
         assert_eq!(v["color"].as_str(), Some("brightgreen"));
@@ -164,7 +164,7 @@ mod tests {
     fn threshold_boundary_is_strictly_greater_than() {
         // An entry exactly at the threshold is not crappy (spec: CRAP > threshold).
         let mut buf = Vec::new();
-        render(&sample(), 110.0, Format::Shields, None, &mut buf).unwrap();
+        render(&sample(), 110.0, Format::Shields, None, None, &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("passing"));
     }
@@ -187,9 +187,18 @@ mod tests {
         let report = compute_delta(&entries, &baseline, 0.01);
 
         let mut delta_buf = Vec::new();
-        render_delta(&report, 30.0, Format::Shields, None, false, &mut delta_buf).unwrap();
+        render_delta(
+            &report,
+            30.0,
+            Format::Shields,
+            None,
+            false,
+            None,
+            &mut delta_buf,
+        )
+        .unwrap();
         let mut plain_buf = Vec::new();
-        render(&entries, 30.0, Format::Shields, None, &mut plain_buf).unwrap();
+        render(&entries, 30.0, Format::Shields, None, None, &mut plain_buf).unwrap();
 
         assert_eq!(
             String::from_utf8(delta_buf).unwrap(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3399,3 +3399,167 @@ fn unknown_flag_exits_with_code_2() {
     // clap's usage exit is part of the documented contract.
     cmd().arg("--frobnicate").assert().code(2);
 }
+
+// --- Scope-mismatch diagnostics (spec 24) ---
+
+#[test]
+fn matching_scopes_emit_no_warning_and_zero_stray_counts() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning:").not())
+        .get_output()
+        .clone();
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let diag = &envelope["diagnostics"];
+    assert_eq!(diag["source_only"]["count"], 0);
+    assert_eq!(diag["lcov_only"]["count"], 0);
+    assert_eq!(diag["analyzed_files"], diag["matched_files"]);
+}
+
+#[test]
+fn no_lcov_means_no_diagnostics_key() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert!(
+        envelope.get("diagnostics").is_none(),
+        "complexity-only run must not carry diagnostics"
+    );
+}
+
+#[test]
+fn lcov_only_files_warn_with_bounded_examples() {
+    // 13 phantom SF records + the real fixture coverage: stderr must show
+    // the lcov_only count, at most 10 examples, and a "... and 3 more"
+    // tail; the JSON examples array is capped at 10 with the exact count.
+    use std::fmt::Write as _;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut lcov = std::fs::read_to_string(fixture_lcov()).expect("read fixture lcov");
+    for i in 0..13 {
+        writeln!(
+            lcov,
+            "SF:/phantom/src/gone_{i:02}.rs\nDA:1,1\nend_of_record"
+        )
+        .expect("string write is infallible");
+    }
+    let lcov_path = dir.path().join("padded.lcov");
+    std::fs::write(&lcov_path, lcov).expect("write lcov");
+
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "13 LCOV file(s) matched no analyzed source file",
+        ))
+        .stderr(predicate::str::contains("... and 3 more"))
+        .get_output()
+        .clone();
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let lcov_only = &envelope["diagnostics"]["lcov_only"];
+    assert_eq!(lcov_only["count"], 13);
+    assert_eq!(
+        lcov_only["examples"].as_array().map(Vec::len),
+        Some(10),
+        "JSON examples must be capped at 10"
+    );
+}
+
+#[test]
+fn zero_overlap_gets_the_no_overlap_wording() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lcov_path = dir.path().join("elsewhere.lcov");
+    std::fs::write(
+        &lcov_path,
+        "SF:/nonexistent/path/src/lib.rs\nDA:1,1\nend_of_record\n",
+    )
+    .expect("write lcov");
+
+    cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .assert()
+        .stderr(predicate::str::contains(
+            "no overlap between the analyzed sources",
+        ))
+        .stderr(predicate::str::contains("describe different scopes"));
+}
+
+#[test]
+fn below_half_overlap_escalates_the_warning() {
+    // 3 analyzed files, LCOV covers 1 → "only 1 of 3" wording.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("src");
+    std::fs::create_dir(&src).expect("mkdir src");
+    for name in ["a", "b", "c"] {
+        std::fs::write(
+            src.join(format!("{name}.rs")),
+            format!("pub fn {name}() {{}}\n"),
+        )
+        .expect("write source");
+    }
+    let lcov_path = dir.path().join("partial.lcov");
+    std::fs::write(&lcov_path, "SF:src/a.rs\nDA:1,1\nend_of_record\n").expect("write lcov");
+
+    cmd()
+        .arg("--path")
+        .arg(&src)
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .assert()
+        .stderr(predicate::str::contains("only 1 of 3 analyzed files"))
+        .stderr(predicate::str::contains("likely describe different scopes"));
+}
+
+#[test]
+fn delta_json_carries_diagnostics_and_validates_against_schema() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = regression_baseline(&dir);
+    let mut lcov = std::fs::read_to_string(fixture_lcov()).expect("read fixture lcov");
+    lcov.push_str("SF:/phantom/src/gone.rs\nDA:1,1\nend_of_record\n");
+    let lcov_path = dir.path().join("padded.lcov");
+    std::fs::write(&lcov_path, lcov).expect("write lcov");
+
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(&lcov_path)
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .get_output()
+        .clone();
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(envelope["diagnostics"]["lcov_only"]["count"], 1);
+
+    let validator = compile_schema("schemas/delta-v2.json");
+    assert_valid(&validator, &envelope);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -108,6 +108,7 @@ fn json_output_round_trips() {
         30.0,
         cargo_crap::report::Format::Json,
         None,
+        None,
         &mut buf,
     )
     .expect("render");


### PR DESCRIPTION
Implements spec 24 for issue #53.

## Problem

When the analyzed tree and the LCOV file describe different scopes (e.g. an analysis root recursively including nested workspace packages absent from the LCOV), every unmatched function scores 0 % covered and a delta fills with unrelated entries. The only clue was an unbounded, one-directional stderr list — no counts, nothing machine-readable, silent about LCOV records that matched no analyzed file.

## Changes

- **`merge()` returns `ScopeDiagnostics`** whenever `--lcov` was supplied: `analyzed_files` / `lcov_files` / `matched_files` counts plus both-direction stray lists. The new `lcov_only` side is tracked by having `PathIndex::lookup` return the raw LCOV key each hit consumed. Example lists are capped at 10 (`SCOPE_EXAMPLE_CAP`); the true `count` is always exact.
- **stderr warning before the report**, tiered by overlap: neutral counts line for small mismatches → "only X of Y analyzed files match — likely describe different scopes" below 50 % → "no overlap" verdict at zero matches. Bounded examples with a "... and N more" tail replace the old unbounded dump.
- **JSON**: both envelopes embed an optional additive `diagnostics` object (`{analyzed_files, lcov_files, matched_files, source_only: {count, examples}, lcov_only: {count, examples}}`), present only when `--lcov` was given. `report-v1.json` / `delta-v2.json` schemas extended in place — optional field, old documents stay valid, no version bump. CI wrappers can gate on the counts.
- No changes to scores, gates, or `--missing` semantics — diagnostics only.

## Library API (for the next release's changelog)

- `MergeResult.unmapped_files` replaced by `MergeResult.diagnostics: Option<ScopeDiagnostics>`.
- `report::render` / `render_delta` gained a `diagnostics: Option<&ScopeDiagnostics>` parameter (spec-16 precedent).

## Verification

- `just dev` clean — 391 tests (13 new unit, 6 new CLI), dogfood clean.
- `just dev-mutants-diff`: 273 mutants — 251 caught, 22 unviable, 0 missed.
- Manual end-to-end: padded LCOV with 13 phantom files → exact spec wording on stderr, capped examples, correct JSON counts.

Closes #53.