### PR TITLE
refactor: replace render/render_delta positional params with RenderOptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,7 @@
 //! use cargo_crap::{
 //!     complexity, coverage,
 //!     merge::{MissingCoveragePolicy, merge},
-//!     report::{Format, render},
-//!     score::DEFAULT_THRESHOLD,
+//!     report::{RenderOptions, render},
 //! };
 //! use std::io;
 //!
@@ -68,8 +67,9 @@
 //! //    treated as 0% covered (the pessimistic default, safest for CI gates).
 //! let entries = merge(fns, cov, MissingCoveragePolicy::Pessimistic).entries;
 //!
-//! // 4. Render the human-readable table to stdout.
-//! render(&entries, DEFAULT_THRESHOLD, Format::Human, None, None, &mut io::stdout())?;
+//! // 4. Render the human-readable table to stdout. `RenderOptions`
+//! //    defaults to the CLI defaults: threshold 30, human format.
+//! render(&entries, &RenderOptions::default(), &mut io::stdout())?;
 //!
 //! # Ok::<(), anyhow::Error>(())
 //! ```
@@ -116,7 +116,7 @@
 //!     complexity, coverage,
 //!     delta::{DEFAULT_EPSILON, compute_delta, load_baseline},
 //!     merge::{MissingCoveragePolicy, merge},
-//!     report::{Format, render_delta},
+//!     report::{RenderOptions, render_delta},
 //! };
 //! use std::io;
 //!
@@ -133,7 +133,7 @@
 //!
 //! // Exit non-zero if any function regressed.
 //! if report.regression_count() > 0 {
-//!     render_delta(&report, 30.0, Format::Human, None, false, None, &mut io::stdout())?;
+//!     render_delta(&report, &RenderOptions::default(), &mut io::stdout())?;
 //!     std::process::exit(1);
 //! }
 //! # Ok::<(), anyhow::Error>(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ use cargo_crap::{
     delta::{compute_delta, load_baseline},
     merge::{MissingCoveragePolicy, ScopeDiagnostics, SortOrder, merge, sort_entries},
     report::{
-        Format, SourceLinks, crappy_count, render, render_delta, render_delta_summary,
-        render_summary, set_color_enabled,
+        Format, RenderOptions, SourceLinks, crappy_count, render, render_delta,
+        render_delta_summary, render_summary, set_color_enabled,
     },
     score::DEFAULT_THRESHOLD,
 };
@@ -982,19 +982,13 @@ fn validate_args(cli: &Cli) -> Result<()> {
 /// keeps the helper's signature under clippy's argument-count limit and makes
 /// call sites readable as "what to render" + "where to render it".
 struct RenderOpts<'a> {
-    threshold: f64,
+    /// Everything the report renderers consume, passed through verbatim.
+    render: RenderOptions<'a>,
     epsilon: f64,
-    format: Format,
     summary: bool,
-    links: Option<&'a SourceLinks>,
-    /// Show `Unchanged` rows in delta mode (spec 16). Only the human and
-    /// markdown renderers consult it.
-    show_unchanged: bool,
     /// Final entry ordering (spec 17). Applied to the `DeltaReport` so
     /// `removed` ordering is deterministic too.
     sort: SortOrder,
-    /// Source/LCOV scope diagnostics (spec 24); embedded in JSON envelopes.
-    diagnostics: Option<&'a ScopeDiagnostics>,
 }
 
 /// Load the `--baseline` file (if any) and filter it through the current
@@ -1048,35 +1042,20 @@ fn do_render(
     if let Some(baseline_data) = baseline {
         let mut report = compute_delta(entries, baseline_data, opts.epsilon);
         report.sort(opts.sort);
-        let has_crappy = crappy_count(entries, opts.threshold) > 0;
+        let has_crappy = crappy_count(entries, opts.render.threshold) > 0;
         let has_regression = report.regression_count() > 0;
         if opts.summary {
             render_delta_summary(&report, out)?;
         } else {
-            render_delta(
-                &report,
-                opts.threshold,
-                opts.format,
-                opts.links,
-                opts.show_unchanged,
-                opts.diagnostics,
-                out,
-            )?;
+            render_delta(&report, &opts.render, out)?;
         }
         Ok((has_crappy, has_regression))
     } else {
-        let has_crappy = crappy_count(entries, opts.threshold) > 0;
+        let has_crappy = crappy_count(entries, opts.render.threshold) > 0;
         if opts.summary {
-            render_summary(entries, opts.threshold, out)?;
+            render_summary(entries, opts.render.threshold, out)?;
         } else {
-            render(
-                entries,
-                opts.threshold,
-                opts.format,
-                opts.links,
-                opts.diagnostics,
-                out,
-            )?;
+            render(entries, &opts.render, out)?;
         }
         Ok((has_crappy, false))
     }
@@ -1214,14 +1193,16 @@ fn run() -> Result<ExitCode> {
     let mut out_box = open_output(cli.output.as_ref())?;
     let links = resolve_source_links(cli.repo_url, cli.commit_ref);
     let opts = RenderOpts {
-        threshold,
+        render: RenderOptions {
+            threshold,
+            format: cli.format.into(),
+            links: links.as_ref(),
+            diagnostics: diagnostics.as_ref(),
+            show_unchanged,
+        },
         epsilon,
-        format: cli.format.into(),
         summary: cli.summary,
-        links: links.as_ref(),
-        show_unchanged,
         sort: sort_order,
-        diagnostics: diagnostics.as_ref(),
     };
     let (has_crappy, has_regression) =
         do_render(&entries, baseline_data.as_deref(), &opts, out_box.as_mut())?;

--- a/src/report.rs
+++ b/src/report.rs
@@ -78,59 +78,98 @@ pub enum Format {
     Shields,
 }
 
-/// Render `entries` in the requested format to `out`.
+/// Options shared by [`render`] and [`render_delta`], so their signatures
+/// survive new knobs without breaking every call site again.
+///
+/// Construct with struct-update syntax over [`Default`]:
+///
+/// ```
+/// use cargo_crap::report::{Format, RenderOptions};
+/// let opts = RenderOptions {
+///     format: Format::Json,
+///     ..Default::default()
+/// };
+/// # let _ = opts;
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RenderOptions<'a> {
+    /// CRAP score above which a function is flagged.
+    pub threshold: f64,
+    /// Output format to dispatch to.
+    pub format: Format,
+    /// GitHub source links for `markdown` / `pr-comment` cells (spec 12).
+    pub links: Option<&'a SourceLinks>,
+    /// Source/LCOV scope diagnostics (spec 24); embedded in the JSON
+    /// envelope only — other formats report mismatches via the CLI's
+    /// stderr warning.
+    pub diagnostics: Option<&'a ScopeDiagnostics>,
+    /// Show `Unchanged` rows in delta mode (spec 16). Only the human and
+    /// markdown renderers consult it; ignored by [`render`].
+    pub show_unchanged: bool,
+}
+
+impl Default for RenderOptions<'_> {
+    /// CLI defaults: threshold 30, human format, no links, no
+    /// diagnostics, changed-only delta rows.
+    fn default() -> Self {
+        Self {
+            threshold: crate::score::DEFAULT_THRESHOLD,
+            format: Format::Human,
+            links: None,
+            diagnostics: None,
+            show_unchanged: false,
+        }
+    }
+}
+
+/// Render `entries` in the format requested by `opts` to `out`.
 ///
 /// For `Format::Human` we emit a table and a summary line. The summary uses
 /// stderr-style coloring if the output is a TTY; `owo-colors` no-ops when
 /// it's not.
-///
-/// `diagnostics` (spec 24) is embedded in the JSON envelope only; every
-/// other format reports scope mismatches via the CLI's stderr warning.
 pub fn render(
     entries: &[CrapEntry],
-    threshold: f64,
-    format: Format,
-    links: Option<&SourceLinks>,
-    diagnostics: Option<&ScopeDiagnostics>,
+    opts: &RenderOptions,
     out: &mut dyn Write,
 ) -> Result<()> {
-    match format {
-        Format::Json => json::render_json(entries, diagnostics, out),
+    let threshold = opts.threshold;
+    match opts.format {
+        Format::Json => json::render_json(entries, opts.diagnostics, out),
         Format::Human => human::render_human(entries, threshold, out),
         Format::GitHub => github::render_github(entries, threshold, out),
-        Format::Markdown => markdown::render_markdown(entries, threshold, links, out),
-        Format::PrComment => pr_comment::render_pr_comment(entries, threshold, links, out),
+        Format::Markdown => markdown::render_markdown(entries, threshold, opts.links, out),
+        Format::PrComment => pr_comment::render_pr_comment(entries, threshold, opts.links, out),
         Format::Sarif => sarif::render_sarif(entries, threshold, out),
         Format::Shields => shields::render_shields(entries, threshold, out),
     }
 }
 
-/// Render a [`DeltaReport`] in the requested format.
+/// Render a [`DeltaReport`] in the format requested by `opts`.
 ///
 /// Human format: table with a Δ column + summary line.
 /// JSON format: `{"entries": [...], "removed": [...]}` object.
 /// GitHub format: `::warning` for regressed and new-crappy functions only.
-/// `show_unchanged` controls whether `Unchanged` rows appear in the human and
-/// markdown tables (spec 16); it has no effect on the other formats, which
-/// keep their own row policies (json stays exhaustive, pr-comment hides
-/// unchanged by design, github/shields/sarif don't list unchanged functions).
+/// `opts.show_unchanged` controls whether `Unchanged` rows appear in the
+/// human and markdown tables (spec 16); it has no effect on the other
+/// formats, which keep their own row policies (json stays exhaustive,
+/// pr-comment hides unchanged by design, github/shields/sarif don't list
+/// unchanged functions).
 pub fn render_delta(
     report: &DeltaReport,
-    threshold: f64,
-    format: Format,
-    links: Option<&SourceLinks>,
-    show_unchanged: bool,
-    diagnostics: Option<&ScopeDiagnostics>,
+    opts: &RenderOptions,
     out: &mut dyn Write,
 ) -> Result<()> {
-    match format {
-        Format::Json => json::render_delta_json(report, diagnostics, out),
-        Format::Human => human::render_delta_human(report, threshold, show_unchanged, out),
+    let threshold = opts.threshold;
+    match opts.format {
+        Format::Json => json::render_delta_json(report, opts.diagnostics, out),
+        Format::Human => human::render_delta_human(report, threshold, opts.show_unchanged, out),
         Format::GitHub => github::render_delta_github(report, threshold, out),
         Format::Markdown => {
-            markdown::render_delta_markdown(report, threshold, links, show_unchanged, out)
+            markdown::render_delta_markdown(report, threshold, opts.links, opts.show_unchanged, out)
         },
-        Format::PrComment => pr_comment::render_delta_pr_comment(report, threshold, links, out),
+        Format::PrComment => {
+            pr_comment::render_delta_pr_comment(report, threshold, opts.links, out)
+        },
         // SARIF describes the *current* set of findings, not deltas. The
         // upstream consumers (GitHub Code Scanning, VS Code) don't model
         // baseline diffs, so combining `--baseline` with `--format sarif`

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -120,7 +120,7 @@ pub(crate) fn gha_escape(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::sample;
+    use super::super::test_support::{opts, sample};
     use super::super::{Format, render};
     use super::*;
     use std::path::PathBuf;
@@ -129,7 +129,7 @@ mod tests {
     fn github_format_emits_warning_for_crappy_function() {
         // Kills: missing the crappy-only guard (`entry.crap > threshold`).
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::GitHub), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("::warning"),
@@ -146,7 +146,7 @@ mod tests {
     fn github_format_clean_function_produces_no_annotation() {
         // Kills: emitting annotations for all functions regardless of threshold.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::GitHub, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::GitHub), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         // "clean" (crap=1.0) is well below threshold=30 and must be silent.
         assert!(
@@ -169,7 +169,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::GitHub, None, None, &mut buf).unwrap();
+        render(&all_clean, &opts(30.0, Format::GitHub), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.is_empty(),
@@ -190,7 +190,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::GitHub, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::GitHub), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("line=42"),

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -281,7 +281,7 @@ fn write_delta_summary(
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::sample;
+    use super::super::test_support::{opts, sample};
     use super::super::{Format, render};
     use super::*;
     use std::path::PathBuf;
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn human_output_mentions_every_function() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("clean"));
         assert!(s.contains("crappy"));
@@ -324,7 +324,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&all_clean, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&all_clean, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains('✓'),
@@ -344,7 +344,7 @@ mod tests {
         // Note: ✓ appears in the row icon for the clean function, so we check
         // the summary count rather than the absence of ✓ in the full output.
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('✗'), "output must show ✗ for crappy functions");
         assert!(s.contains("1/2"), "summary must report 1 out of 2 crappy");
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn empty_entries_prints_no_functions_found() {
         let mut buf = Vec::new();
-        render(&[], 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&[], &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("No functions found."));
     }
@@ -371,7 +371,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('—'), "None coverage must render as —");
     }
@@ -389,7 +389,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("44.4"), "Some(44.4) must render as 44.4");
     }
@@ -418,7 +418,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&both_crappy, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&both_crappy, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("2/2"), "both functions crappy, must report 2/2");
     }
@@ -438,7 +438,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('▲'), "moderate score must show ▲");
         assert!(!s.contains('✗'), "moderate score must not show ✗");
@@ -448,7 +448,7 @@ mod tests {
     fn render_human_includes_per_crate_section_when_workspace() {
         let entries = vec![entry(Some("alpha"), "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("Per-crate summary:"),
@@ -461,7 +461,7 @@ mod tests {
     fn render_human_omits_per_crate_section_when_no_workspace_data() {
         let entries = vec![entry(None, "a1", 1.0)];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Human, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             !s.contains("Per-crate summary"),

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -100,15 +100,15 @@ pub(crate) fn render_delta_json(
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::sample;
-    use super::super::{Format, render};
+    use super::super::test_support::{opts, sample};
+    use super::super::{Format, RenderOptions, render};
     use super::*;
     use std::path::PathBuf;
 
     #[test]
     fn json_output_is_envelope_with_version_and_entries() {
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Json, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::Json), &mut buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert!(parsed.is_object(), "JSON output must be an envelope object");
         assert_eq!(
@@ -144,7 +144,17 @@ mod tests {
         };
 
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Json, None, Some(&diag), &mut buf).unwrap();
+        render(
+            &sample(),
+            &RenderOptions {
+                threshold: 30.0,
+                format: Format::Json,
+                diagnostics: Some(&diag),
+                ..Default::default()
+            },
+            &mut buf,
+        )
+        .unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert_eq!(parsed["diagnostics"]["analyzed_files"], 4);
         assert_eq!(parsed["diagnostics"]["lcov_files"], 3);
@@ -157,7 +167,7 @@ mod tests {
         assert_eq!(parsed["diagnostics"]["lcov_only"]["count"], 1);
 
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Json, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::Json), &mut buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert!(
             parsed.get("diagnostics").is_none(),
@@ -179,7 +189,17 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::Json, Some(&links), None, &mut buf).unwrap();
+        render(
+            &entries,
+            &RenderOptions {
+                threshold: 30.0,
+                format: Format::Json,
+                links: Some(&links),
+                ..Default::default()
+            },
+            &mut buf,
+        )
+        .unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             !s.contains("](https://"),

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -247,7 +247,7 @@ fn write_markdown_delta_body(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{Format, render};
+    use super::super::{Format, RenderOptions, render};
     use super::*;
     use std::path::PathBuf;
 
@@ -264,15 +264,12 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "main".into());
         let mut buf = Vec::new();
-        render(
-            &entries,
-            30.0,
-            Format::Markdown,
-            Some(&links),
-            None,
-            &mut buf,
-        )
-        .unwrap();
+        let opts = RenderOptions {
+            format: Format::Markdown,
+            links: Some(&links),
+            ..Default::default()
+        };
+        render(&entries, &opts, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("[`foo`](https://github.com/o/r/blob/main/src/a.rs#L7)"),

--- a/src/report/pr_comment.rs
+++ b/src/report/pr_comment.rs
@@ -548,7 +548,8 @@ pub(crate) fn render_pr_comment(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{Format, render};
+    use super::super::test_support::opts;
+    use super::super::{Format, RenderOptions, render};
     use super::*;
 
     fn delta_entry(
@@ -1066,7 +1067,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.starts_with("<!-- cargo-crap-report -->"));
     }
@@ -1083,7 +1084,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("## ✅ No CRAP threshold violations"));
     }
@@ -1145,7 +1146,7 @@ mod tests {
             },
         ];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
 
         // Only `above` must appear in the table; the headline still shows it.
@@ -1175,7 +1176,7 @@ mod tests {
             crate_name: None,
         }];
         let mut buf = Vec::new();
-        render(&entries, 30.0, Format::PrComment, None, None, &mut buf).unwrap();
+        render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("`very_crappy`"),
@@ -1478,15 +1479,12 @@ mod tests {
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "abc".into());
         let mut buf = Vec::new();
-        render(
-            &entries,
-            30.0,
-            Format::PrComment,
-            Some(&links),
-            None,
-            &mut buf,
-        )
-        .unwrap();
+        let opts = RenderOptions {
+            format: Format::PrComment,
+            links: Some(&links),
+            ..Default::default()
+        };
+        render(&entries, &opts, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("[`very_crappy`](https://github.com/o/r/blob/abc/src/a.rs#L42)"),

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -194,13 +194,18 @@ fn normalize_path(p: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::sample;
-    use super::super::{Format, render};
+    use super::super::test_support::{opts, sample};
+    use super::super::{Format, RenderOptions, render};
     use super::*;
 
     fn render_to_value(threshold: f64) -> serde_json::Value {
         let mut buf = Vec::new();
-        render(&sample(), threshold, Format::Sarif, None, None, &mut buf).unwrap();
+        let opts = RenderOptions {
+            threshold,
+            format: Format::Sarif,
+            ..Default::default()
+        };
+        render(&sample(), &opts, &mut buf).unwrap();
         serde_json::from_slice(&buf).expect("output must be valid JSON")
     }
 
@@ -270,7 +275,7 @@ mod tests {
     #[test]
     fn empty_entries_produce_valid_sarif_with_empty_results() {
         let mut buf = Vec::new();
-        render(&[], 30.0, Format::Sarif, None, None, &mut buf).unwrap();
+        render(&[], &opts(30.0, Format::Sarif), &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["version"].as_str(), Some(SARIF_VERSION));
         let results = v["runs"][0]["results"]
@@ -306,7 +311,7 @@ mod tests {
             removed: Vec::new(),
         };
         let mut buf = Vec::new();
-        let err = render_delta(&report, 30.0, Format::Sarif, None, false, None, &mut buf)
+        let err = render_delta(&report, &opts(30.0, Format::Sarif), &mut buf)
             .expect_err("delta + sarif must fail");
         let msg = err.to_string();
         assert!(

--- a/src/report/shields.rs
+++ b/src/report/shields.rs
@@ -83,7 +83,7 @@ fn write_badge(
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::sample;
+    use super::super::test_support::{opts, sample};
     use super::super::{Format, render, render_delta};
     use crate::delta::compute_delta;
 
@@ -145,7 +145,7 @@ mod tests {
     fn render_counts_entries_above_threshold() {
         // sample() has one entry above 30 (CRAP 110) and one below (CRAP 1).
         let mut buf = Vec::new();
-        render(&sample(), 30.0, Format::Shields, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(30.0, Format::Shields), &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("1 crappy"));
         assert_eq!(v["color"].as_str(), Some("yellow"));
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn render_with_high_threshold_is_passing() {
         let mut buf = Vec::new();
-        render(&sample(), 200.0, Format::Shields, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(200.0, Format::Shields), &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("passing"));
         assert_eq!(v["color"].as_str(), Some("brightgreen"));
@@ -164,7 +164,7 @@ mod tests {
     fn threshold_boundary_is_strictly_greater_than() {
         // An entry exactly at the threshold is not crappy (spec: CRAP > threshold).
         let mut buf = Vec::new();
-        render(&sample(), 110.0, Format::Shields, None, None, &mut buf).unwrap();
+        render(&sample(), &opts(110.0, Format::Shields), &mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).expect("valid JSON");
         assert_eq!(v["message"].as_str(), Some("passing"));
     }
@@ -187,18 +187,9 @@ mod tests {
         let report = compute_delta(&entries, &baseline, 0.01);
 
         let mut delta_buf = Vec::new();
-        render_delta(
-            &report,
-            30.0,
-            Format::Shields,
-            None,
-            false,
-            None,
-            &mut delta_buf,
-        )
-        .unwrap();
+        render_delta(&report, &opts(30.0, Format::Shields), &mut delta_buf).unwrap();
         let mut plain_buf = Vec::new();
-        render(&entries, 30.0, Format::Shields, None, None, &mut plain_buf).unwrap();
+        render(&entries, &opts(30.0, Format::Shields), &mut plain_buf).unwrap();
 
         assert_eq!(
             String::from_utf8(delta_buf).unwrap(),

--- a/src/report/test_support.rs
+++ b/src/report/test_support.rs
@@ -4,8 +4,23 @@
 //! respective tests; only fixtures used by *more than one* submodule end up
 //! here.
 
+use super::{Format, RenderOptions};
 use crate::merge::CrapEntry;
 use std::path::PathBuf;
+
+/// Shorthand for the common test shape: a threshold and a format, every
+/// other knob at its default. Sites needing links / diagnostics /
+/// `show_unchanged` spell out the struct literal instead.
+pub(crate) fn opts(
+    threshold: f64,
+    format: Format,
+) -> RenderOptions<'static> {
+    RenderOptions {
+        threshold,
+        format,
+        ..Default::default()
+    }
+}
 
 /// Two-entry fixture: one trivially clean function and one egregiously
 /// crappy function. Used by the json / human / github / dispatcher tests

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,15 +103,11 @@ fn json_output_round_trips() {
     let entries = merge(complexity, coverage, MissingCoveragePolicy::Pessimistic).entries;
 
     let mut buf = Vec::new();
-    cargo_crap::report::render(
-        &entries,
-        30.0,
-        cargo_crap::report::Format::Json,
-        None,
-        None,
-        &mut buf,
-    )
-    .expect("render");
+    let opts = cargo_crap::report::RenderOptions {
+        format: cargo_crap::report::Format::Json,
+        ..Default::default()
+    };
+    cargo_crap::report::render(&entries, &opts, &mut buf).expect("render");
 
     // If this parses, the output is well-formed.
     let parsed: serde_json::Value =


### PR DESCRIPTION
`render` took 6 positional arguments and `render_delta` 7 — every new knob (spec 16's `show_unchanged`, spec 24's `diagnostics`) broke all call sites and read as argument soup at each one.

## Changes

- New public `report::RenderOptions<'a>` — `threshold`, `format`, `links`, `diagnostics`, `show_unchanged` — with a `Default` matching the CLI defaults (threshold 30, human format), so callers use struct-update syntax and future fields stop being signature breaks:

  ```rust
  render(&entries, &RenderOptions { format: Format::Json, ..Default::default() }, &mut out)?;
  ```

- `render(entries, &opts, out)` / `render_delta(report, &opts, out)` — 3 parameters each. Dispatch logic unchanged.
- `main`'s private `RenderOpts` embeds a `RenderOptions` verbatim plus its CLI-only extras (`epsilon`, `summary`, `sort`) instead of duplicating five fields.
- Renderer tests share a `test_support::opts(threshold, format)` shorthand for the common no-extras shape (26 sites); tests setting `links`/`diagnostics`/`show_unchanged` keep explicit literals. `lib.rs` doctests updated; the `RenderOptions` doc example compiles as a doctest.
- Deliberately no builder methods: struct literal + `Default` is the idiomatic pattern and keeps the API surface minimal.

## Compatibility

Breaking for library consumers — intentionally landing in 0.4.0 alongside the spec-24 signature change so downstream migrates once, straight to the final API. The 0.4.0 release branch's migration guide will be updated to show these signatures after this merges. No CLI-visible changes.

## Verification

- `just dev` clean — 216 unit + 41 integration + 155 CLI + 6 doctests, dogfood clean (177 functions).
- `just dev-mutants-diff`: 277 mutants — 258 caught, 19 unviable, 0 missed, 0 timeouts.