### PR TITLE
fix: nested items no longer inflate the enclosing function's CC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
 
 **`src/score.rs`** — Pure formula: `CRAP(m) = comp(m)² × (1 − cov(m)/100)³ + comp(m)`. No I/O, no dependencies on other modules.
 
-**`src/complexity.rs`** — Uses `syn` to walk the Rust AST and extract `FunctionComplexity` tuples. Handles `ItemFn` (free functions) and `ImplItemFn` (methods) via the `Visit` trait. Closures are not recursed into — their decision points belong to their own scope. Uses the `ignore` crate to respect `.gitignore` during `analyze_tree`. The `proc-macro2` dependency must have the `span-locations` feature enabled to call `Span::start()`/`Span::end()` at runtime.
+**`src/complexity.rs`** — Uses `syn` to walk the Rust AST and extract `FunctionComplexity` tuples. Handles `ItemFn` (free functions) and `ImplItemFn` (methods) via the `Visit` trait. Closures and items nested inside function bodies (local `fn` / `impl` / `mod` / …) are not recursed into — their decision points belong to their own scope. Uses the `ignore` crate to respect `.gitignore` during `analyze_tree`. The `proc-macro2` dependency must have the `span-locations` feature enabled to call `Span::start()`/`Span::end()` at runtime.
 
 **`src/coverage.rs`** — Parses LCOV files using the `lcov` crate. Only consumes `SF` (source file), `DA` (line data), and `end_of_record` records. Path normalization is deliberately absent here — that responsibility belongs to `merge`.
 

--- a/src/complexity.rs
+++ b/src/complexity.rs
@@ -20,7 +20,10 @@ use syn::{
 /// coverage report later.
 #[derive(Debug, Clone, Serialize)]
 pub struct FunctionComplexity {
-    /// Absolute path to the source file.
+    /// Path to the source file, exactly as produced by the walk: absolute
+    /// when the analysis root was absolute, relative otherwise (e.g. under
+    /// the CLI default `--path .`). Never canonicalized here — path
+    /// resolution against coverage data is `merge`'s job.
     pub file: PathBuf,
     /// Function name. Closures are not extracted as separate entries.
     pub name: String,
@@ -243,6 +246,18 @@ impl<'ast> Visit<'ast> for CcCounter {
         // Do not recurse into closures: their decision points belong to their
         // own logical scope, not to the enclosing function's CC.
     }
+
+    fn visit_item(
+        &mut self,
+        _node: &'ast syn::Item,
+    ) {
+        // Do not recurse into items nested in the function body (a local
+        // `fn`, `impl`, `mod`, `trait`, `const`, …): like closures, they are
+        // their own logical scope. Without this stop, syn's default visitor
+        // walks `Stmt::Item` and a helper fn defined inside the body would
+        // silently inflate the enclosing function's CC while never being
+        // reported itself.
+    }
 }
 
 /// Build a `GlobSet` from a slice of glob pattern strings.
@@ -369,6 +384,82 @@ fn check(x: i32) -> &'static str {
             fns[0].cyclomatic >= 3.0,
             "expected CC ≥ 3 for two-branch if/else, got {}",
             fns[0].cyclomatic
+        );
+    }
+
+    #[test]
+    fn nested_fn_does_not_inflate_enclosing_cc() {
+        // A local helper fn is its own scope, exactly like a closure: its
+        // decision points must not leak into the outer function's count.
+        let f = write_temp(
+            r"
+fn outer() -> i32 {
+    fn inner(y: i32) -> i32 {
+        if y > 0 { y } else { -y }
+    }
+    inner(1)
+}
+",
+        );
+        let fns = analyze_file(f.path()).expect("analyze");
+        assert_eq!(fns.len(), 1, "nested fns are not extracted as entries");
+        assert_eq!(fns[0].name, "outer");
+        assert_eq!(
+            fns[0].cyclomatic, 1.0,
+            "inner's `if` must not count toward outer"
+        );
+    }
+
+    #[test]
+    fn nested_impl_and_mod_do_not_inflate_enclosing_cc() {
+        let f = write_temp(
+            r"
+fn outer() -> u32 {
+    struct S;
+    impl S {
+        fn branchy(x: u32) -> u32 {
+            match x {
+                0 => 1,
+                1 => 2,
+                _ => 3,
+            }
+        }
+    }
+    mod local {
+        pub fn helper(b: bool) -> bool {
+            b && !b || b
+        }
+    }
+    S::branchy(local::helper(true) as u32)
+}
+",
+        );
+        let fns = analyze_file(f.path()).expect("analyze");
+        assert_eq!(fns.len(), 1);
+        assert_eq!(
+            fns[0].cyclomatic, 1.0,
+            "match arms and boolean operators inside nested impl/mod items \
+             must not count toward outer"
+        );
+    }
+
+    #[test]
+    fn code_after_a_nested_item_still_counts() {
+        // The item stop must not swallow the rest of the enclosing body:
+        // decision points after the nested fn still belong to outer.
+        let f = write_temp(
+            r"
+fn outer(x: i32) -> i32 {
+    fn inner() -> i32 { 1 }
+    if x > 0 { inner() } else { 0 }
+}
+",
+        );
+        let fns = analyze_file(f.path()).expect("analyze");
+        assert_eq!(fns.len(), 1);
+        assert_eq!(
+            fns[0].cyclomatic, 2.0,
+            "outer's own `if` after the nested item must still count"
         );
     }
 


### PR DESCRIPTION
Found by the whole-source review (confidence 88, reproduced before fixing).

## Bug

`CcCounter` stops at closure boundaries but had no stop for *items* nested in a function body. `syn`'s default visitor walks `Stmt::Item`, so a local helper `fn`'s branches counted toward the **enclosing** function — while the helper itself never gets its own entry:

```rust
fn outer() -> i32 {
    fn inner(y: i32) -> i32 {
        if y > 0 { y } else { -y }
    }
    inner(1)
}
```

`outer` reported CC 2 instead of 1. Same for local `impl` blocks and `mod`s. This contradicts the module's own scoping rationale ("decision points belong to their own scope") and inflates CRAP for the common local-helper pattern — potentially pushing simple functions over `--threshold`.

## Fix

One no-op `visit_item` override in `CcCounter` — the visitor-pattern idiom for pruning a subtree. It stops CC propagation at **every** nested-item class (`fn`, `impl`, `mod`, `trait`, `const`, …) exactly like the existing closure stop, and can't miss an item kind the way per-kind overrides could. Nested items remain unextracted (consistent with closures).

Three regression tests: nested `fn`, nested `impl`+`mod` (match arms + boolean ops), and the over-stopping guard — decision points *after* a nested item still count.

Also in this PR: `FunctionComplexity::file`'s doc claimed "absolute path", but it carries whatever the analysis root produced (relative under the default `--path .`) — doc corrected, CLAUDE.md architecture note updated.

## Behavior note for reviewers

Scores can **decrease** for functions containing local helpers. Committed baselines will show one-time `improved` entries after upgrade (never regressions — the gate is unaffected). Will be called out in the 0.4.0 changelog.

## Verification

- `just dev` clean — 219 unit (3 new) + full CLI suite, dogfood clean.
- `just dev-mutants-diff`: 47 mutants — 43 caught, 4 unviable, 0 missed.