### PR TITLE
fix: validate merged epsilon/jobs, not just the CLI flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -959,6 +959,26 @@ fn path_is_ignored(cli: &Cli) -> bool {
     cli.workspace || !cli.package.is_empty()
 }
 
+/// Validate knobs that can arrive from either the CLI or the config file.
+///
+/// [`validate_args`] only sees raw CLI values, so a config-sourced value
+/// must be re-checked after the merge — otherwise `.cargo-crap.toml`
+/// smuggles in values the equivalent flag would reject (a negative epsilon
+/// silently classifies every unchanged function as `Regressed`; the config
+/// docs promise both bounds).
+fn validate_merged_values(
+    epsilon: f64,
+    jobs: Option<usize>,
+) -> Result<()> {
+    if epsilon < 0.0 {
+        bail!("invalid epsilon value (--epsilon or config): must be non-negative");
+    }
+    if matches!(jobs, Some(0)) {
+        bail!("invalid jobs value (--jobs or config): must be a positive integer");
+    }
+    Ok(())
+}
+
 /// Validate argument combinations that clap cannot express as declarative rules.
 fn validate_args(cli: &Cli) -> Result<()> {
     if !path_is_ignored(cli) && !cli.path.exists() {
@@ -1129,6 +1149,8 @@ fn run() -> Result<ExitCode> {
         .epsilon
         .or(config.epsilon)
         .unwrap_or(cargo_crap::delta::DEFAULT_EPSILON);
+    let jobs = cli.jobs.or(config.jobs);
+    validate_merged_values(epsilon, jobs)?;
 
     let effective_exclude = effective_excludes(
         cli.no_default_excludes,
@@ -1150,7 +1172,7 @@ fn run() -> Result<ExitCode> {
         &cli.package,
         &cli.path,
         &effective_exclude,
-        cli.jobs.or(config.jobs),
+        jobs,
     )?;
 
     pb.set_message("Parsing coverage report…");
@@ -1505,6 +1527,27 @@ mod tests {
             nested_member_excludes(Path::new("/ws/parent/nested"), &discovered).is_empty(),
             "a member never excludes itself"
         );
+    }
+
+    #[test]
+    fn validate_merged_values_truth_table() {
+        // (epsilon, jobs) → ok? Negative epsilon and zero jobs are the two
+        // values the config file could previously smuggle past the
+        // CLI-only checks.
+        assert!(
+            validate_merged_values(0.0, None).is_ok(),
+            "zero epsilon is valid"
+        );
+        assert!(validate_merged_values(0.01, Some(4)).is_ok());
+        assert!(
+            validate_merged_values(-0.001, None).is_err(),
+            "negative epsilon"
+        );
+        assert!(validate_merged_values(0.01, Some(0)).is_err(), "zero jobs");
+        let err = validate_merged_values(-1.0, Some(0))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("epsilon"), "epsilon is checked first: {err}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1125,8 +1125,42 @@ fn main() -> ExitCode {
     }
 }
 
-fn run() -> Result<ExitCode> {
+/// Everything [`run`] needs after parsing: the raw CLI/config plus the
+/// merged-and-validated values that [`validate_args`] (CLI-only) cannot
+/// check itself.
+struct LoadedArgs {
+    cli: Cli,
+    config: cargo_crap::config::Config,
+    epsilon: f64,
+    jobs: Option<usize>,
+}
+
+/// Parse argv, load config, and validate the merged epsilon/jobs values,
+/// returning exactly what was validated so [`run`] cannot consume a
+/// different (unchecked) merge of the same knobs.
+fn parse_and_validate() -> Result<LoadedArgs> {
     let (cli, config) = parse_and_load_config()?;
+    let epsilon = cli
+        .epsilon
+        .or(config.epsilon)
+        .unwrap_or(cargo_crap::delta::DEFAULT_EPSILON);
+    let jobs = cli.jobs.or(config.jobs);
+    validate_merged_values(epsilon, jobs)?;
+    Ok(LoadedArgs {
+        cli,
+        config,
+        epsilon,
+        jobs,
+    })
+}
+
+fn run() -> Result<ExitCode> {
+    let LoadedArgs {
+        cli,
+        config,
+        epsilon,
+        jobs,
+    } = parse_and_validate()?;
 
     // Merge: CLI values take precedence; config fills in what's missing.
     let threshold = cli
@@ -1144,13 +1178,6 @@ fn run() -> Result<ExitCode> {
     let fail_regression = resolve_bool(cli.fail_regression, config.fail_regression);
     let show_unchanged = resolve_bool(cli.show_unchanged, config.show_unchanged);
     let sort_order = cli.sort.map(Into::into).or(config.sort).unwrap_or_default();
-
-    let epsilon = cli
-        .epsilon
-        .or(config.epsilon)
-        .unwrap_or(cargo_crap::delta::DEFAULT_EPSILON);
-    let jobs = cli.jobs.or(config.jobs);
-    validate_merged_values(epsilon, jobs)?;
 
     let effective_exclude = effective_excludes(
         cli.no_default_excludes,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3974,3 +3974,58 @@ fn package_outside_a_cargo_project_exits_2() {
         .code(2)
         .stderr(predicate::str::contains("cargo metadata"));
 }
+
+// --- Config-sourced value validation (whole-source review finding) ---
+
+#[test]
+fn config_negative_epsilon_is_rejected() {
+    // A negative epsilon via .cargo-crap.toml previously bypassed the
+    // CLI-only check and made classify_score mark every unchanged (and
+    // even improved) function as regressed. Must be a tool error (exit 2).
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(".cargo-crap.toml"), "epsilon = -0.5\n").expect("write config");
+    let abs_src = std::fs::canonicalize(fixture_src()).expect("canonicalize fixture");
+
+    cmd()
+        .current_dir(dir.path())
+        .arg("--path")
+        .arg(&abs_src)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("must be non-negative"));
+}
+
+#[test]
+fn config_zero_jobs_is_rejected() {
+    // Same bypass for jobs = 0: the config docs promise "non-zero when
+    // set", and --jobs 0 already errors — the config path must match.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(".cargo-crap.toml"), "jobs = 0\n").expect("write config");
+    let abs_src = std::fs::canonicalize(fixture_src()).expect("canonicalize fixture");
+
+    cmd()
+        .current_dir(dir.path())
+        .arg("--path")
+        .arg(&abs_src)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("must be a positive integer"));
+}
+
+#[test]
+fn cli_epsilon_overriding_bad_config_epsilon_is_accepted() {
+    // The merged value is what matters: a valid --epsilon must win over an
+    // invalid config value, exactly as CLI-over-config precedence promises.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(".cargo-crap.toml"), "epsilon = -0.5\n").expect("write config");
+    let abs_src = std::fs::canonicalize(fixture_src()).expect("canonicalize fixture");
+
+    cmd()
+        .current_dir(dir.path())
+        .arg("--path")
+        .arg(&abs_src)
+        .arg("--epsilon")
+        .arg("0.1")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
Found independently by two reviewers in the whole-source review (confidence 90, reproduced before fixing).

## Bug

`validate_args` only checks `cli.epsilon` / `cli.jobs` — the values merged from `.cargo-crap.toml` bypass validation entirely, despite the config docs promising the same bounds:

- `epsilon = -0.5` in config → `classify_score`'s `delta > epsilon` is satisfied by every delta above the negative bound. Reproduced: a byte-identical run against its own baseline classified **every** function as `regressed` and `--fail-regression` exited 1 on a no-op, with no error explaining why.
- `jobs = 0` in config → silently falls back to rayon auto-sizing, where `--jobs 0` is a hard error.

## Fix

`run()` now calls `validate_merged_values(epsilon, jobs)` immediately after the CLI/config merge — invalid values exit 2 (spec 23 tool-error class) regardless of source. The CLI-only checks in `validate_args` stay for their earlier, flag-specific messages. Precedence is preserved: a valid `--epsilon` overriding an invalid config value succeeds, because the *merged* value is what's validated.

## Tests

Unit truth table for `validate_merged_values` plus three CLI tests: config negative epsilon → exit 2, config zero jobs → exit 2, valid CLI flag over invalid config → success.

## Verification

- `just dev` clean — 158 CLI tests (3 new), dogfood clean.
- `just dev-mutants-diff`: 138 mutants — 125 caught, 13 unviable, 0 missed.