### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.1] - 2026-08-02
+
+### Added
+
+- `FileCoverage::merge_from` (library): fold another file's line data
+  into this one — union of lines, per-line saturating sum of hit
+  counts. This is the same aggregation `lcov -a` performs.
+
+### Fixed
+
+- **Deterministic path resolution for ambiguous LCOV inputs** (spec 26,
+  #62). The index joining complexity and coverage data resolved
+  ambiguity nondeterministically: when several relative LCOV keys
+  suffix-matched one file (`src/lib.rs` vs `vendor/dep/src/lib.rs`),
+  the winner was hash-order random per process, and two absolute keys
+  spelling the same real file (symlinked roots, `lcov -a`-merged legs)
+  collided last-write-wins — so byte-identical inputs could produce
+  different scores across runs. Now the longest (most specific) suffix
+  wins, and different spellings of one file merge their line data
+  instead of racing. Degenerate `SF` records (`SF:.`, empty `SF:`) no
+  longer risk wildcard-binding unmapped files; they surface as
+  `lcov_only` strays in the scope diagnostics.
+
+  Note: scores can change for genuinely ambiguous or aliased inputs —
+  those scores were coin-flips before, so any change there is the fix
+  landing. Standard single-run `cargo llvm-cov` output cannot trigger
+  either case and is unaffected.
+
 ## [0.4.0] - 2026-07-31
 
 This release implements specs 23–25 — the three feature requests filed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Oleksandr Prokhorenko <warbles.lieu_04@icloud.com>"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cargo-crap
 
-[![v0.4.0](https://img.shields.io/badge/v0.4.0-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.0)
+[![v0.4.1](https://img.shields.io/badge/v0.4.1-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.1)
 [![crates.io](https://img.shields.io/badge/crates.io-E57300?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/crates/cargo-crap)
-[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.0/cargo_crap/)
+[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.1/cargo_crap/)
 [![CRAP](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fminikin%2Fcargo-crap%2Fbadges%2Fcrap-badge.json&style=for-the-badge)](https://github.com/minikin/cargo-crap/actions/workflows/ci.yml)
 
 > [!TIP]


### PR DESCRIPTION
## 0.4.1 — patch release

Everything on main since v0.4.0: spec 26 (#67) and its implementation (#68).

### Fixed
- **Deterministic path resolution for ambiguous LCOV inputs** (spec 26, #62): longest-suffix preference on the slow path, merge-instead-of-race for aliased spellings (symlinked roots, `lcov -a` legs, `./`-variants), degenerate `SF` records surface as strays instead of wildcard-binding.

### Added
- `FileCoverage::merge_from` (library, additive): per-line saturating-sum aggregation, same semantics as `lcov -a`.

No breaking changes: `merge()`, `CrapEntry`, the JSON envelope, and both schemas are untouched. Scores can change only for genuinely ambiguous/aliased inputs — those were coin-flips before, so any change there is the fix landing. Standard single-run `cargo llvm-cov` output is unaffected.

This PR: version bump to 0.4.1, changelog entry, README badge bump. `just dev` clean; mutation tests skipped (no source changes in this diff).
