### PR TITLE
fix: percent-encode source link paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rayon = "1"
 indicatif = "0.18.4"
 lcov = "0.8"
 owo-colors = "4"
+percent-encoding = "2"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/report/links.rs
+++ b/src/report/links.rs
@@ -6,7 +6,16 @@
 //! never have to branch on link presence beyond passing `Option<&SourceLinks>`
 //! through to [`linkify`].
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use std::path::{Path, PathBuf};
+
+/// RFC 3986 unreserved bytes plus `/`, which must remain a path separator.
+const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
 
 /// Repo URL + commit ref used by `markdown` / `pr-comment` renderers to wrap
 /// Function and Location cells in clickable source links.
@@ -51,6 +60,7 @@ impl SourceLinks {
         line: usize,
     ) -> String {
         let path = file.to_string_lossy().replace('\\', "/");
+        let path = utf8_percent_encode(&path, PATH_ENCODE_SET);
         format!(
             "{}/blob/{}/{}#L{}",
             self.repo_url, self.commit_ref, path, line
@@ -132,5 +142,25 @@ mod tests {
             "URL must contain no backslashes, got: {url}"
         );
         assert_eq!(url, "https://github.com/o/r/blob/sha/src/foo.rs#L1");
+    }
+
+    #[test]
+    fn source_links_percent_encodes_reserved_path_bytes() {
+        let l = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let url = l.url_for(Path::new("src/a file#50%?(draft).rs"), 7);
+        assert_eq!(
+            url,
+            "https://github.com/o/r/blob/sha/src/a%20file%2350%25%3F%28draft%29.rs#L7"
+        );
+    }
+
+    #[test]
+    fn source_links_percent_encodes_utf8_path_bytes() {
+        let l = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
+        let url = l.url_for(Path::new("src/数据.rs"), 9);
+        assert_eq!(
+            url,
+            "https://github.com/o/r/blob/sha/src/%E6%95%B0%E6%8D%AE.rs#L9"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- percent-encode repository path bytes in Markdown and PR-comment source links
- preserve RFC 3986 unreserved characters and `/` path separators
- cover reserved ASCII characters, literal percent signs, parentheses, and UTF-8 paths

## Motivation

`SourceLinks::url_for` normalized Windows path separators but interpolated the
remaining path verbatim into a Markdown link. A valid repository path containing
a space, `#`, `?`, `%`, or parentheses could therefore truncate the GitHub URL or
break the Markdown destination. This violated the existing source-link contract
for otherwise analyzable Rust files.

## Design

The path is normalized to forward slashes first, then percent-encoded byte-wise.
RFC 3986 unreserved characters (`A-Z`, `a-z`, digits, `-`, `.`, `_`, `~`) and `/`
remain unchanged, so ordinary source links are byte-identical. Using the focused
`percent-encoding` crate avoids maintaining a partial character replacement list.

This change intentionally applies only to GitHub source links. SARIF artifact URI
normalization is a separate output contract and remains out of scope.

## Testing

- `cargo test report::links::tests -- --nocapture` — passed (5 tests)
- `cargo test report::markdown::tests -- --nocapture` — passed (6 tests)
- `cargo test report::pr_comment::tests -- --nocapture` — passed (39 tests)
- `just --shell <git-sh> lint` — passed (rustfmt and Clippy with warnings denied)
- `cargo test --all-targets` — passed (226 tests)
- `cargo test --doc` — passed
- `just --shell <git-sh> dogfood` — passed (LLVM LCOV self-score, threshold 15)
- `cargo mutants --file src/report/links.rs` — passed (7/7 mutants caught)

`cargo-nextest` was not available locally: its documented Cargo installation
failed once while downloading `gimli` from crates.io and did not complete on a
second attempt. The all-target native suite was rerun with `cargo test` instead.
Installing the Rust 1.88 toolchain also did not complete locally, so the existing
remote MSRV job remains the authoritative Rust 1.88 check.

## Compatibility and risks

Ordinary ASCII paths and Windows separators retain their previous output. Only
bytes that are unsafe in a URI/Markdown destination change, to their uppercase
percent-encoded form. The new dependency is small and already existed in the
lockfile as a transitive development dependency.

## Scope

- no changes to SARIF artifact URIs
- no changes to commit-ref or repository-URL validation
- no changes to the configurable `?`-operator work in #70

