### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.2] - 2026-08-04
+
+### Fixed
+
+- **Source links percent-encode repository paths** (#71, thanks
+  @alectimison-maker). `markdown` / `pr-comment` source links
+  interpolated the file path verbatim, so a path containing a space,
+  `#`, `?`, `%`, or parentheses truncated the GitHub URL or broke the
+  Markdown link destination. Paths are now percent-encoded byte-wise
+  after separator normalization; RFC 3986 unreserved characters and
+  `/` pass through untouched, so ordinary source links are
+  byte-identical to previous releases.
+
 ## [0.4.1] - 2026-08-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Oleksandr Prokhorenko <warbles.lieu_04@icloud.com>"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cargo-crap
 
-[![v0.4.1](https://img.shields.io/badge/v0.4.1-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.1)
+[![v0.4.2](https://img.shields.io/badge/v0.4.2-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.2)
 [![crates.io](https://img.shields.io/badge/crates.io-E57300?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/crates/cargo-crap)
-[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.1/cargo_crap/)
+[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.2/cargo_crap/)
 [![CRAP](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fminikin%2Fcargo-crap%2Fbadges%2Fcrap-badge.json&style=for-the-badge)](https://github.com/minikin/cargo-crap/actions/workflows/ci.yml)
 
 > [!TIP]


### PR DESCRIPTION
## 0.4.2 — patch release

One change since v0.4.1: #71 by @alectimison-maker.

### Fixed
- **Source links percent-encode repository paths.** `markdown` / `pr-comment` links interpolated the path verbatim, so a space, `#`, `?`, `%`, or parentheses truncated the GitHub URL or broke the Markdown destination. Paths are now percent-encoded after separator normalization; unreserved characters and `/` pass through, so ordinary links are byte-identical to previous releases.

No API changes; the new `percent-encoding` dependency is internal (zero transitive deps, was already in the tree via jsonschema dev-deps).

This PR: version bump to 0.4.2, changelog entry, README badge bump. `just dev` clean; mutation tests skipped (no source changes in this diff).
