### PR TITLE
fix: escape GitHub annotation file properties

### DIFF
--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -44,7 +44,7 @@ pub(crate) fn render_github(
         writeln!(
             out,
             "::warning file={file},line={line},title=CRAP ({crap:.1} > {threshold})::{msg}",
-            file = file.display(),
+            file = gha_escape_property(&file.display().to_string()),
             line = entry.line,
             crap = entry.crap,
             threshold = threshold,
@@ -101,7 +101,7 @@ pub(crate) fn render_delta_github(
         writeln!(
             out,
             "::warning file={file},line={line},title=CRAP ({crap:.1})::{msg}",
-            file = file.display(),
+            file = gha_escape_property(&file.display().to_string()),
             line = e.line,
             crap = e.crap,
             msg = gha_escape(&message),
@@ -116,6 +116,12 @@ pub(crate) fn gha_escape(s: &str) -> String {
     s.replace('%', "%25")
         .replace('\r', "%0D")
         .replace('\n', "%0A")
+}
+
+/// Percent-encode the additional delimiters that are special inside GitHub
+/// Actions workflow-command properties.
+fn gha_escape_property(s: &str) -> String {
+    gha_escape(s).replace(':', "%3A").replace(',', "%2C")
 }
 
 #[cfg(test)]
@@ -209,6 +215,34 @@ mod tests {
         assert_eq!(gha_escape("a\rb"), "a%0Db");
         assert_eq!(gha_escape("a\nb"), "a%0Ab");
         assert_eq!(gha_escape("plain"), "plain"); // no-op for clean strings
+    }
+
+    #[test]
+    fn gha_escape_property_encodes_property_delimiters() {
+        assert_eq!(gha_escape_property("a:b,c"), "a%3Ab%2Cc");
+        assert_eq!(gha_escape_property("plain/path.rs"), "plain/path.rs");
+    }
+
+    #[test]
+    fn github_format_escapes_file_command_properties() {
+        let entries = vec![CrapEntry {
+            file: PathBuf::from("src/a,b:c%\n::error::bad.rs"),
+            function: "bad".into(),
+            line: 42,
+            cyclomatic: 10.0,
+            coverage: Some(0.0),
+            crap: 110.0,
+            crate_name: None,
+        }];
+        let mut buf = Vec::new();
+        render(&entries, &opts(30.0, Format::GitHub), &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+
+        assert_eq!(s.lines().count(), 1, "path must not inject another command");
+        assert!(
+            s.contains("file=src/a%2Cb%3Ac%25%0A%3A%3Aerror%3A%3Abad.rs,line=42"),
+            "file property must follow workflow-command escaping: {s:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- escape GitHub Actions workflow-command reserved bytes in annotation `file` properties
- use the same property encoding for absolute and delta GitHub reports
- cover delimiter escaping and command-shaped path input with focused regression tests

## Motivation

The GitHub renderer already escaped annotation messages, but it interpolated file paths directly into the workflow-command property list. A path containing `%`, CR, LF, `:`, or `,` could corrupt the annotation or produce an additional command-shaped line.

## Design

Add a property-specific helper that reuses the existing data escaping and additionally encodes the `:` and `,` property delimiters. Ordinary paths remain byte-for-byte unchanged, and the implementation adds no dependency or public API.

## Testing

- `just --shell powershell.exe --shell-arg -NoProfile --shell-arg -Command dev`
- `CARGO_NET_OFFLINE=true cargo mutants --file src/report/github.rs` (13/13 mutants caught)
- `cargo test --all-targets --offline` (435 passed)
- `cargo fmt --all -- --check`

## Compatibility

Only file paths containing GitHub workflow-command reserved bytes change, and they now follow the command-property encoding rules. JSON, human, Markdown, SARIF, and other report formats are unaffected.
