### PR TITLE
chore(release): 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.3] - 2026-08-06
+
+### Fixed
+
+- **GitHub annotations escape file-path properties** (#73, thanks
+  @alectimison-maker). The `github` format escaped annotation messages
+  but interpolated file paths verbatim into the workflow-command
+  property list, so a path containing `%`, CR, LF, `:`, or `,` could
+  corrupt the `::warning` annotation — or, with an embedded newline,
+  inject an additional command-shaped line into the CI log. File
+  properties now follow GitHub's command-property encoding (the
+  `escapeProperty` rules from actions/toolkit); ordinary paths are
+  byte-for-byte unchanged.
+
 ## [0.4.2] - 2026-08-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Oleksandr Prokhorenko <warbles.lieu_04@icloud.com>"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cargo-crap
 
-[![v0.4.2](https://img.shields.io/badge/v0.4.2-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.2)
+[![v0.4.3](https://img.shields.io/badge/v0.4.3-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.3)
 [![crates.io](https://img.shields.io/badge/crates.io-E57300?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/crates/cargo-crap)
-[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.2/cargo_crap/)
+[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.3/cargo_crap/)
 [![CRAP](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fminikin%2Fcargo-crap%2Fbadges%2Fcrap-badge.json&style=for-the-badge)](https://github.com/minikin/cargo-crap/actions/workflows/ci.yml)
 
 > [!TIP]


### PR DESCRIPTION
## 0.4.3 — patch release

One change since v0.4.2: #73 by @alectimison-maker.

### Fixed
- **GitHub annotations escape file-path properties.** The `github` format escaped messages but interpolated file paths verbatim into the workflow-command property list — a path with `%`, CR, LF, `:`, or `,` could corrupt the `::warning` annotation, or inject an additional command-shaped line via an embedded newline. File properties now follow GitHub's `escapeProperty` rules; ordinary paths are byte-for-byte unchanged.

No API changes, no new dependencies.

This PR: version bump to 0.4.3, changelog entry, README badge bump. `just dev` clean; mutation tests skipped (no source changes in this diff).

Release mechanics after merge: tag `v0.4.3` → binaries → GitHub release → crates.io.