### PR TITLE
feat: uncovered-span hints (spec 28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ generate types directly from the schema.
       "cyclomatic": 4.0,
       "coverage": 75.0,        // null when no coverage data was found
       "crap": 5.5625,
-      "crate": "my-crate"      // present only with --workspace
+      "crate": "my-crate",     // present only with --workspace
+      "uncovered": [           // uncovered line ranges; omitted when empty
+        { "start": 15, "end": 16 }
+      ]
     }
   ]
 }
@@ -242,6 +245,12 @@ epsilon = 0.01            # regression-detector tolerance
 jobs    = 4               # cap parallel analysis at 4 threads
 sort    = "file"          # entry ordering: crap (default) | file
 show_unchanged = false    # list Unchanged rows in --baseline mode
+# Append an Uncovered column (per-function uncovered line ranges, e.g.
+# `142–158, 171, 180–184 +2 more`) to the human, markdown, and pr-comment
+# outputs.
+# Config-only — there is deliberately no CLI flag. JSON always carries
+# the full ranges regardless of this key.
+uncovered-hints = false
 ```
 
 All keys are optional. Unknown keys are rejected to catch typos.

--- a/schemas/delta-v2.json
+++ b/schemas/delta-v2.json
@@ -58,6 +58,11 @@
         },
         "crap": { "type": "number", "minimum": 1 },
         "crate": { "type": "string" },
+        "uncovered": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/LineRange" },
+          "description": "Maximal runs of instrumented-but-never-hit lines inside the function's span, from the current run. Omitted when empty or when the file had no coverage data at all."
+        },
         "baseline_crap": {
           "type": ["number", "null"],
           "description": "CRAP score from the baseline run; null when this function is new."
@@ -74,6 +79,23 @@
         "previous_file": {
           "type": "string",
           "description": "Baseline location when this entry was paired across files. Omitted when the entry was matched on the exact (file, function) pair (the common case) or is genuinely new."
+        }
+      }
+    },
+    "LineRange": {
+      "type": "object",
+      "required": ["start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first uncovered line of the range (inclusive)."
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last uncovered line of the range (inclusive)."
         }
       }
     },

--- a/schemas/report-v1.json
+++ b/schemas/report-v1.json
@@ -65,6 +65,28 @@
         "crate": {
           "type": "string",
           "description": "Cargo workspace member name. Present only on `--workspace` runs."
+        },
+        "uncovered": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/LineRange" },
+          "description": "Maximal runs of instrumented-but-never-hit lines inside the function's span. Omitted when empty or when the file had no coverage data at all."
+        }
+      }
+    },
+    "LineRange": {
+      "type": "object",
+      "required": ["start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first uncovered line of the range (inclusive)."
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last uncovered line of the range (inclusive)."
         }
       }
     },

--- a/specs/23-exit-code-contract.md
+++ b/specs/23-exit-code-contract.md
@@ -1,6 +1,6 @@
 # Spec 23 — Exit-code contract: policy failures vs tool errors
 
-**Status:** Proposed (issue #54)
+**Status:** Implemented (issue #54)
 **Effort:** Small
 **Module:** `src/main.rs` (+ README, `tests/cli.rs`)
 

--- a/specs/24-scope-mismatch-diagnostics.md
+++ b/specs/24-scope-mismatch-diagnostics.md
@@ -1,6 +1,6 @@
 # Spec 24 — Source/LCOV scope-mismatch diagnostics
 
-**Status:** Proposed (issue #53)
+**Status:** Implemented (issue #53)
 **Effort:** Medium
 **Module:** `src/merge.rs`, `src/main.rs`, `src/report/json.rs`, `schemas/`
 

--- a/specs/25-repeatable-package-selector.md
+++ b/specs/25-repeatable-package-selector.md
@@ -1,6 +1,6 @@
 # Spec 25 — Repeatable `--package` selector for workspace analysis
 
-**Status:** Proposed (issue #55)
+**Status:** Implemented (issue #55)
 **Effort:** Medium
 **Module:** `src/main.rs` (CLI, `analyze_sources`, baseline filtering)
 

--- a/specs/26-deterministic-path-index.md
+++ b/specs/26-deterministic-path-index.md
@@ -1,6 +1,6 @@
 # Spec 26 — Deterministic path resolution in the merge index
 
-**Status:** Proposed (issue #62)
+**Status:** Implemented (issue #62)
 **Effort:** Medium
 **Module:** `src/merge.rs` (plus a small merge helper on `FileCoverage` in `src/coverage.rs`)
 

--- a/specs/28-uncovered-span-hints.md
+++ b/specs/28-uncovered-span-hints.md
@@ -1,6 +1,6 @@
 # Spec 28 — Uncovered-span hints
 
-**Status:** Proposed
+**Status:** Implemented
 **Effort:** Medium
 **Module:** `src/coverage.rs` (range helper), `src/merge.rs` (populate), `src/config.rs` (new key), `src/report/` (render), `schemas/` (spec-03 schema update)
 
@@ -180,9 +180,9 @@ the `default-excludes` precedent. Default off.
 - A shared formatter in `report/types.rs` (`uncovered_display`):
   en-dash ranges, comma-separated, cap 3 + `+N more`, bare number for
   single-line ranges.
-- **human** — extra `Uncovered` column when the key is on; it joins the
-  spec-20 width-aware layout as the lowest-priority column (first to
-  drop when the terminal is narrow).
+- **human** — extra `Uncovered` column when the key is on. If/when
+  spec 20's width-aware layout lands, this column should join it as
+  lowest priority (first to drop when the terminal is narrow).
 - **markdown / pr-comment** — extra column in their tables, same
   formatter.
 - **json** — field always present when non-empty (see scenario); the

--- a/specs/28-uncovered-span-hints.md
+++ b/specs/28-uncovered-span-hints.md
@@ -1,0 +1,203 @@
+# Spec 28 — Uncovered-span hints
+
+**Status:** Proposed
+**Effort:** Medium
+**Module:** `src/coverage.rs` (range helper), `src/merge.rs` (populate), `src/config.rs` (new key), `src/report/` (render), `schemas/` (spec-03 schema update)
+
+## Context
+
+The report says *which* functions are crappy but not *why they stay
+crappy*: a `CRAP 87` row gives no clue where the missing tests should
+aim. The data to answer that already flows through the merge layer —
+`coverage_in_span` intersects the function's AST span with the LCOV `DA`
+records — but the per-line detail is collapsed into a single percentage
+and thrown away.
+
+This spec keeps it: each entry gains a list of **uncovered ranges** —
+maximal runs of instrumented-but-never-hit lines inside the function's
+span. Rendered compactly (`142–158, 171, 180–184`), they turn the
+report from a scoreboard into a to-do list: the reader knows exactly
+which branches to write tests for, without opening a coverage HTML
+report on the side.
+
+Two definitions anchor everything below:
+
+- **Uncovered line** — a line inside `[start_line..=end_line]` that has
+  a `DA` record with 0 hits. Lines *without* a `DA` record (comments,
+  braces, blank lines, non-executable code) are neither covered nor
+  uncovered; they are invisible to this feature.
+- **Uncovered range** — a maximal inclusive run of uncovered lines.
+  Only a *covered* instrumented line (hits > 0) breaks a range;
+  non-instrumented lines in between are coalesced over. Range endpoints
+  are always uncovered instrumented lines — a range never starts or
+  ends on non-instrumented padding.
+
+Per house style, no new CLI flag: human-readable rendering is gated by
+a config key. The JSON format always carries the data — it is the
+machine format, and the field is additive.
+
+---
+
+## Acceptance Tests
+
+### Scenario: Uncovered lines group into maximal ranges
+
+```
+Given a function spanning lines 10–20
+And   DA records: 10 (3 hits), 12 (0), 13 (0), 14 (0), 16 (2 hits), 18 (0)
+When  the report is computed
+Then  the entry's uncovered ranges are [12–14, 18]
+And   line 16, being covered, splits the runs — 12–14 and 18 never merge
+```
+
+### Scenario: Non-instrumented lines never split a range
+
+```
+Given a function spanning lines 10–20
+And   DA records: 12 (0 hits), 15 (0 hits), 18 (0 hits)
+And   lines 13–14 and 16–17 carry no DA records at all
+When  the report is computed
+Then  the uncovered ranges are [12–18] — one range, coalesced across
+      the non-instrumented gaps
+And   the range starts at 12 and ends at 18, never extending onto
+      non-instrumented lines outside the run
+```
+
+### Scenario: A fully covered function has no ranges
+
+```
+Given a function whose every instrumented line has hits > 0
+When  the report is computed
+Then  its uncovered ranges are empty
+And   nothing renders in any format for that entry
+```
+
+### Scenario: Unknown coverage is not "uncovered"
+
+```
+Given a source file that appears nowhere in the LCOV report
+And   the default `--missing pessimistic` policy scoring it as 0%
+When  the report is computed
+Then  its entries carry no uncovered ranges
+And   no hint renders — "the report never mentioned this file" must
+      stay distinguishable from "these exact lines were never hit"
+```
+
+### Scenario: Lines outside the function span never contribute
+
+```
+Given a function spanning lines 10–20
+And   an uncovered DA record on line 25 belonging to the next function
+When  the report is computed
+Then  no range of the 10–20 function includes line 25
+```
+
+### Scenario: JSON always carries the field
+
+```
+Given entries with non-empty uncovered ranges
+When  rendering with `--format json`
+Then  each such entry has an `uncovered` array of `{start, end}`
+      objects with inclusive bounds
+And   entries with no ranges omit the field entirely
+And   the config key below has no effect on JSON output
+```
+
+### Scenario: Older baselines load unchanged
+
+```
+Given a `--format json` baseline written before this spec
+When  it is loaded via `--baseline`
+Then  loading succeeds; absent `uncovered` deserializes as empty
+And   delta matching and score comparison are unaffected — the field
+      is never part of any pairing key
+```
+
+### Scenario: Rendering is opt-in via config, not a flag
+
+```
+Given `.cargo-crap.toml` containing `uncovered-hints = true`
+When  rendering human, markdown, or pr-comment output
+Then  each displayed entry with ranges shows an Uncovered cell,
+      e.g. `12–14, 18`
+Given no config key (or `uncovered-hints = false`)
+Then  no Uncovered cell appears anywhere — output is byte-identical
+      to today's
+And   no CLI flag exists for this; the key is config-only
+```
+
+### Scenario: Rendered ranges are capped, JSON is not
+
+```
+Given an entry with 5 uncovered ranges and `uncovered-hints = true`
+When  rendering human, markdown, or pr-comment output
+Then  the cell shows the first 3 ranges followed by `+2 more`
+And   a single-line range renders as a bare number (`17`, not `17–17`)
+And   `--format json` still carries all 5 ranges
+```
+
+### Scenario: Delta mode hints come from the current run
+
+```
+Given `--baseline` mode with `uncovered-hints = true`
+When  the delta report renders
+Then  each current-run row shows its own uncovered ranges
+And   `removed` baseline entries never render hints
+```
+
+---
+
+## Implementation Notes
+
+### `FileCoverage::uncovered_ranges_in_span` (`src/coverage.rs`)
+
+Sibling of `coverage_in_span`: one pass over
+`self.lines.range(start..=end)`, opening a range on an unhit line,
+extending it on subsequent unhit lines, and closing it (at the last
+unhit line seen) when a hit line appears. Returns `Vec<LineRange>`
+with inclusive bounds. Same span-degenerate behavior as its sibling:
+no instrumented lines → empty vec.
+
+### `CrapEntry` (`src/merge.rs`)
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub uncovered: Vec<LineRange>,   // LineRange { start: u32, end: u32 }
+```
+
+Populated inside `merge()` from the same `lookup` hit that feeds
+`coverage_in_span`; `None` hits (file unmatched) leave it empty under
+every `--missing` policy. `serde(default)` covers pre-spec baselines.
+
+### Config (`src/config.rs`)
+
+`uncovered_hints: Option<bool>` with `#[serde(alias)]` so both
+`uncovered-hints` (house style) and `uncovered_hints` parse, matching
+the `default-excludes` precedent. Default off.
+
+### Rendering (`src/report/`)
+
+- A shared formatter in `report/types.rs` (`uncovered_display`):
+  en-dash ranges, comma-separated, cap 3 + `+N more`, bare number for
+  single-line ranges.
+- **human** — extra `Uncovered` column when the key is on; it joins the
+  spec-20 width-aware layout as the lowest-priority column (first to
+  drop when the terminal is narrow).
+- **markdown / pr-comment** — extra column in their tables, same
+  formatter.
+- **json** — field always present when non-empty (see scenario); the
+  envelope version already mirrors the crate version, so consumers see
+  the addition with the release bump. Update the spec-03 schema.
+- **github / sarif / shields / summary** — unchanged.
+
+### Non-goals
+
+- No SARIF `relatedLocations` for uncovered regions — a natural
+  follow-up, but out of scope here.
+- No hit-count detail (`0/3 branch legs`) — LCOV `BRDA` records and
+  branch-aware scoring are a separate feature.
+- No threshold gating of hints: every *displayed* row renders its
+  ranges when the key is on. Which rows are displayed remains the job
+  of `--threshold` / `--min` / `--top` / caps, unchanged.
+- No change to scoring, matching, or delta semantics — the field is
+  payload, never key.

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@
 //! sort = "file"
 //! # Show Unchanged rows in --baseline mode (human / markdown).
 //! show_unchanged = true
+//! # Append an Uncovered column (uncovered line ranges) to the human,
+//! # markdown, and pr-comment outputs.
+//! uncovered-hints = true
 //! ```
 
 use crate::merge::{MissingCoveragePolicy, SortOrder};
@@ -92,6 +95,13 @@ pub struct Config {
     /// Accepted as `show-unchanged` (house style) or `show_unchanged`.
     #[serde(alias = "show_unchanged")]
     pub show_unchanged: Option<bool>,
+
+    /// Append an `Uncovered` column (uncovered line ranges per function) to
+    /// the human, markdown, and pr-comment outputs. Defaults to false.
+    /// Config-only — there is deliberately no CLI flag. Accepted as
+    /// `uncovered-hints` (house style) or `uncovered_hints`.
+    #[serde(alias = "uncovered_hints")]
+    pub uncovered_hints: Option<bool>,
 }
 
 /// Walk up from `start` until `.cargo-crap.toml` is found.
@@ -238,6 +248,23 @@ allow = ["Foo::*"]
         let cfg = load(dir.path()).unwrap();
         assert!(cfg.sort.is_none());
         assert!(cfg.show_unchanged.is_none());
+        assert!(cfg.uncovered_hints.is_none());
+    }
+
+    #[test]
+    fn uncovered_hints_kebab_case_is_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(dir.path(), "uncovered-hints = true\n");
+        let cfg = load(dir.path()).unwrap();
+        assert_eq!(cfg.uncovered_hints, Some(true));
+    }
+
+    #[test]
+    fn uncovered_hints_snake_case_alias_is_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(dir.path(), "uncovered_hints = false\n");
+        let cfg = load(dir.path()).unwrap();
+        assert_eq!(cfg.uncovered_hints, Some(false));
     }
 
     #[test]

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -22,8 +22,32 @@ use anyhow::{Context, Result};
 use lcov::reader::Error as LcovReadError;
 use lcov::record::ParseRecordError;
 use lcov::{Reader, Record};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+
+/// Inclusive range of instrumented-but-never-hit lines.
+///
+/// Endpoints are always lines that carry a `DA` record with 0 hits;
+/// non-instrumented lines may sit *inside* a range (they don't break a
+/// run) but never start or end one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+#[cfg(test)]
+impl LineRange {
+    /// Test-only shorthand shared by the coverage and report test modules:
+    /// build a range list from `(start, end)` pairs.
+    pub(crate) fn list(pairs: &[(u32, u32)]) -> Vec<Self> {
+        pairs
+            .iter()
+            .map(|&(start, end)| Self { start, end })
+            .collect()
+    }
+}
 
 /// Per-file coverage, indexed by line number.
 ///
@@ -76,6 +100,42 @@ impl FileCoverage {
         }
         let covered = executable.iter().filter(|(_, hits)| **hits > 0).count();
         (covered as f64 / executable.len() as f64) * 100.0
+    }
+
+    /// Maximal runs of uncovered instrumented lines in `[start..=end]`.
+    ///
+    /// Only a *covered* instrumented line (hits > 0) closes a run;
+    /// non-instrumented gaps are coalesced over. A range's `end` is the
+    /// last unhit line seen, so ranges never extend onto non-instrumented
+    /// padding. A span with no instrumented lines yields no ranges,
+    /// mirroring `coverage_in_span`'s "nothing to cover" stance.
+    #[must_use]
+    pub fn uncovered_ranges_in_span(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Vec<LineRange> {
+        let start = start as u32;
+        let end = end as u32;
+        let mut ranges = Vec::new();
+        let mut open: Option<LineRange> = None;
+        for (&line, &hits) in self.lines.range(start..=end) {
+            if hits == 0 {
+                match open.as_mut() {
+                    Some(range) => range.end = line,
+                    None => {
+                        open = Some(LineRange {
+                            start: line,
+                            end: line,
+                        });
+                    },
+                }
+            } else if let Some(range) = open.take() {
+                ranges.push(range);
+            }
+        }
+        ranges.extend(open);
+        ranges
     }
 }
 
@@ -286,5 +346,61 @@ mod tests {
         let fc = fc_from(&[(5, 1), (10, 1), (15, 1)]);
         // Only line 10 is inside [10..=10].
         assert_eq!(fc.coverage_in_span(10, 10), 100.0);
+    }
+
+    #[test]
+    fn uncovered_runs_split_only_on_covered_lines() {
+        // Spec 28: line 16 (covered) splits the runs; 12–14 and 18 never merge.
+        let fc = fc_from(&[(10, 3), (12, 0), (13, 0), (14, 0), (16, 2), (18, 0)]);
+        assert_eq!(
+            fc.uncovered_ranges_in_span(10, 20),
+            LineRange::list(&[(12, 14), (18, 18)])
+        );
+    }
+
+    #[test]
+    fn non_instrumented_gaps_do_not_split_a_range() {
+        // Spec 28: lines 13–14 and 16–17 carry no DA records — the run
+        // coalesces across them into 12–18, and endpoints stay on
+        // instrumented lines.
+        let fc = fc_from(&[(12, 0), (15, 0), (18, 0)]);
+        assert_eq!(
+            fc.uncovered_ranges_in_span(10, 20),
+            LineRange::list(&[(12, 18)])
+        );
+    }
+
+    #[test]
+    fn fully_covered_span_has_no_ranges() {
+        let fc = fc_from(&[(10, 1), (11, 2)]);
+        assert!(fc.uncovered_ranges_in_span(10, 20).is_empty());
+    }
+
+    #[test]
+    fn span_with_no_instrumented_lines_has_no_ranges() {
+        // Mirrors `coverage_in_span`'s "nothing to cover" stance.
+        let fc = fc_from(&[(5, 0), (25, 0)]);
+        assert!(fc.uncovered_ranges_in_span(10, 20).is_empty());
+    }
+
+    #[test]
+    fn uncovered_lines_outside_the_span_never_contribute() {
+        // Spec 28: line 25 belongs to the next function.
+        let fc = fc_from(&[(12, 0), (25, 0)]);
+        assert_eq!(
+            fc.uncovered_ranges_in_span(10, 20),
+            LineRange::list(&[(12, 12)])
+        );
+    }
+
+    #[test]
+    fn trailing_open_run_is_closed_at_its_last_unhit_line() {
+        // A run still open at the end of the span must be emitted, ending
+        // on the last unhit line — not on the span bound.
+        let fc = fc_from(&[(10, 1), (11, 0), (12, 0)]);
+        assert_eq!(
+            fc.uncovered_ranges_in_span(10, 20),
+            LineRange::list(&[(11, 12)])
+        );
     }
 }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -478,6 +478,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: None,
+            uncovered: Vec::new(),
         }
     }
 
@@ -623,6 +624,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 5.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let baseline = vec![CrapEntry {
             file: PathBuf::from("src/main.rs"), // different file, same function name
@@ -632,6 +634,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 5.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
         assert_eq!(
@@ -662,6 +665,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 10.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let baseline = vec![CrapEntry {
             file: PathBuf::from("tests/fixtures/src/lib.rs"),
@@ -671,6 +675,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 5.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let report = compute_delta(&current, &baseline, DEFAULT_EPSILON);
         assert_eq!(
@@ -753,6 +758,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: None,
+            uncovered: Vec::new(),
         }
     }
 
@@ -953,6 +959,7 @@ mod tests {
                 coverage: Some(0.0),
                 crap: 30.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             CrapEntry {
                 file: PathBuf::from("src/lib.rs"),
@@ -962,6 +969,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
         ];
         let current = baseline.clone();
@@ -995,6 +1003,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: None,
+            uncovered: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,6 +1191,9 @@ fn run() -> Result<ExitCode> {
     let fail_above = resolve_bool(cli.fail_above, config.fail_above);
     let fail_regression = resolve_bool(cli.fail_regression, config.fail_regression);
     let show_unchanged = resolve_bool(cli.show_unchanged, config.show_unchanged);
+    // Config-only knob: deliberately no CLI flag, so there is no CLI side
+    // to resolve against.
+    let uncovered_hints = config.uncovered_hints.unwrap_or(false);
     let sort_order = cli.sort.map(Into::into).or(config.sort).unwrap_or_default();
 
     let effective_exclude = effective_excludes(
@@ -1262,6 +1265,7 @@ fn run() -> Result<ExitCode> {
             links: links.as_ref(),
             diagnostics: diagnostics.as_ref(),
             show_unchanged,
+            uncovered_hints,
         },
         epsilon,
         summary: cli.summary,
@@ -1765,6 +1769,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -29,7 +29,7 @@
 //! instead of racing on map order.
 
 use crate::complexity::FunctionComplexity;
-use crate::coverage::FileCoverage;
+use crate::coverage::{FileCoverage, LineRange};
 use crate::score::crap;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -55,6 +55,13 @@ pub struct CrapEntry {
     /// pre-date this field.
     #[serde(rename = "crate", default, skip_serializing_if = "Option::is_none")]
     pub crate_name: Option<String>,
+    /// Maximal runs of instrumented-but-never-hit lines inside the
+    /// function's span. Empty when the file had no coverage data
+    /// at all — "unknown" must stay distinguishable from "known-uncovered"
+    /// — and for baselines that pre-date this field. Payload only: never
+    /// part of any delta pairing key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uncovered: Vec<LineRange>,
 }
 
 /// Final ordering applied to the report entries (spec 17).
@@ -194,6 +201,13 @@ pub fn merge(
         .filter_map(|fc| {
             let hit = index.lookup(&fc.file);
             let cov = hit.map(|found| found.cov.coverage_in_span(fc.start_line, fc.end_line));
+            let uncovered = hit
+                .map(|found| {
+                    found
+                        .cov
+                        .uncovered_ranges_in_span(fc.start_line, fc.end_line)
+                })
+                .unwrap_or_default();
 
             if has_coverage {
                 if let Some(found) = hit {
@@ -219,6 +233,7 @@ pub fn merge(
                 coverage: cov,
                 crap: crap_score,
                 crate_name: None,
+                uncovered,
             })
         })
         .collect();
@@ -938,6 +953,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: None,
+            uncovered: Vec::new(),
         }
     }
 
@@ -1022,5 +1038,86 @@ mod tests {
             result.diagnostics.is_none(),
             "no lcov → no scope diagnostics, no warnings"
         );
+    }
+
+    #[test]
+    fn merge_populates_uncovered_ranges_from_matched_coverage() {
+        // Kills: dropping the `uncovered_ranges_in_span` call in merge()
+        // (field left Vec::new() for matched files).
+        let complexity = vec![FunctionComplexity {
+            file: PathBuf::from("/repo/src/foo.rs"),
+            name: "foo".into(),
+            start_line: 10,
+            end_line: 20,
+            cyclomatic: 3.0,
+        }];
+        let mut cov_map = HashMap::new();
+        cov_map.insert(
+            PathBuf::from("src/foo.rs"),
+            cov_with(&[(10, 3), (12, 0), (13, 0), (16, 2), (18, 0)]),
+        );
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        assert_eq!(
+            result.entries[0].uncovered,
+            vec![
+                LineRange { start: 12, end: 13 },
+                LineRange { start: 18, end: 18 },
+            ],
+        );
+    }
+
+    #[test]
+    fn unmatched_file_has_no_uncovered_ranges_even_when_pessimistic() {
+        // "The report never mentioned this file" must stay distinguishable
+        // from "these exact lines were never hit": pessimistic scores the
+        // function 0% but must not fabricate uncovered ranges.
+        let complexity = vec![FunctionComplexity {
+            file: PathBuf::from("/repo/src/foo.rs"),
+            name: "foo".into(),
+            start_line: 10,
+            end_line: 20,
+            cyclomatic: 3.0,
+        }];
+        let mut cov_map = HashMap::new();
+        cov_map.insert(PathBuf::from("src/other.rs"), cov_with(&[(10, 0)]));
+        let result = merge(complexity, cov_map, MissingCoveragePolicy::Pessimistic);
+        assert_eq!(result.entries[0].coverage, None);
+        assert!(result.entries[0].uncovered.is_empty());
+    }
+
+    #[test]
+    fn uncovered_field_is_optional_on_deserialize_and_skipped_when_empty() {
+        // Baselines written before the field existed must load unchanged,
+        // and entries without ranges must serialize byte-identically to the
+        // pre-field output (kills dropping serde(default) / skip_serializing_if).
+        let old_json = r#"{"file":"a.rs","function":"f","line":1,"cyclomatic":1.0,"coverage":null,"crap":1.0}"#;
+        let e: CrapEntry = serde_json::from_str(old_json).expect("pre-field baseline loads");
+        assert!(e.uncovered.is_empty());
+        let ser = serde_json::to_string(&e).expect("serialize");
+        assert!(
+            !ser.contains("uncovered"),
+            "empty ranges must be omitted, got: {ser}"
+        );
+    }
+
+    #[test]
+    fn uncovered_field_round_trips_through_json() {
+        let e = CrapEntry {
+            file: PathBuf::from("a.rs"),
+            function: "f".into(),
+            line: 1,
+            cyclomatic: 2.0,
+            coverage: Some(50.0),
+            crap: 4.5,
+            crate_name: None,
+            uncovered: vec![LineRange { start: 3, end: 5 }],
+        };
+        let ser = serde_json::to_string(&e).expect("serialize");
+        assert!(
+            ser.contains(r#""uncovered":[{"start":3,"end":5}]"#),
+            "ranges serialize as start/end objects, got: {ser}"
+        );
+        let back: CrapEntry = serde_json::from_str(&ser).expect("deserialize");
+        assert_eq!(back.uncovered, e.uncovered);
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -106,11 +106,16 @@ pub struct RenderOptions<'a> {
     /// Show `Unchanged` rows in delta mode (spec 16). Only the human and
     /// markdown renderers consult it; ignored by [`render`].
     pub show_unchanged: bool,
+    /// Append an `Uncovered` column listing each entry's uncovered line
+    /// ranges. Config-only (`uncovered-hints` in
+    /// `.cargo-crap.toml`); consulted by the human, markdown, and
+    /// pr-comment renderers. JSON always carries the data regardless.
+    pub uncovered_hints: bool,
 }
 
 impl Default for RenderOptions<'_> {
     /// CLI defaults: threshold 30, human format, no links, no
-    /// diagnostics, changed-only delta rows.
+    /// diagnostics, changed-only delta rows, no uncovered hints.
     fn default() -> Self {
         Self {
             threshold: crate::score::DEFAULT_THRESHOLD,
@@ -118,6 +123,7 @@ impl Default for RenderOptions<'_> {
             links: None,
             diagnostics: None,
             show_unchanged: false,
+            uncovered_hints: false,
         }
     }
 }
@@ -135,10 +141,14 @@ pub fn render(
     let threshold = opts.threshold;
     match opts.format {
         Format::Json => json::render_json(entries, opts.diagnostics, out),
-        Format::Human => human::render_human(entries, threshold, out),
+        Format::Human => human::render_human(entries, threshold, opts.uncovered_hints, out),
         Format::GitHub => github::render_github(entries, threshold, out),
-        Format::Markdown => markdown::render_markdown(entries, threshold, opts.links, out),
-        Format::PrComment => pr_comment::render_pr_comment(entries, threshold, opts.links, out),
+        Format::Markdown => {
+            markdown::render_markdown(entries, threshold, opts.links, opts.uncovered_hints, out)
+        },
+        Format::PrComment => {
+            pr_comment::render_pr_comment(entries, threshold, opts.links, opts.uncovered_hints, out)
+        },
         Format::Sarif => sarif::render_sarif(entries, threshold, out),
         Format::Shields => shields::render_shields(entries, threshold, out),
     }
@@ -162,14 +172,29 @@ pub fn render_delta(
     let threshold = opts.threshold;
     match opts.format {
         Format::Json => json::render_delta_json(report, opts.diagnostics, out),
-        Format::Human => human::render_delta_human(report, threshold, opts.show_unchanged, out),
+        Format::Human => human::render_delta_human(
+            report,
+            threshold,
+            opts.show_unchanged,
+            opts.uncovered_hints,
+            out,
+        ),
         Format::GitHub => github::render_delta_github(report, threshold, out),
-        Format::Markdown => {
-            markdown::render_delta_markdown(report, threshold, opts.links, opts.show_unchanged, out)
-        },
-        Format::PrComment => {
-            pr_comment::render_delta_pr_comment(report, threshold, opts.links, out)
-        },
+        Format::Markdown => markdown::render_delta_markdown(
+            report,
+            threshold,
+            opts.links,
+            opts.show_unchanged,
+            opts.uncovered_hints,
+            out,
+        ),
+        Format::PrComment => pr_comment::render_delta_pr_comment(
+            report,
+            threshold,
+            opts.links,
+            opts.uncovered_hints,
+            out,
+        ),
         // SARIF describes the *current* set of findings, not deltas. The
         // upstream consumers (GitHub Code Scanning, VS Code) don't model
         // baseline diffs, so combining `--baseline` with `--format sarif`

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -173,6 +173,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&all_clean, &opts(30.0, Format::GitHub), &mut buf).unwrap();
@@ -194,6 +195,7 @@ mod tests {
             coverage: Some(0.0),
             crap: 110.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::GitHub), &mut buf).unwrap();
@@ -233,6 +235,7 @@ mod tests {
             coverage: Some(0.0),
             crap: 110.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::GitHub), &mut buf).unwrap();
@@ -263,6 +266,7 @@ mod tests {
                     coverage: Some(50.0),
                     crap: 35.0,
                     crate_name: None,
+                    uncovered: Vec::new(),
                 },
                 baseline_crap: Some(20.0),
                 delta: Some(15.0),
@@ -296,6 +300,7 @@ mod tests {
                     coverage: Some(80.0),
                     crap: 5.0,
                     crate_name: None,
+                    uncovered: Vec::new(),
                 },
                 baseline_crap: Some(5.0),
                 delta: Some(0.0),

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -3,7 +3,8 @@
 
 use super::per_crate::write_per_crate_human;
 use super::types::{
-    Grade, apply_table_styling, coverage_bar, delta_display, styled, visible_delta_entries,
+    Grade, apply_table_styling, coverage_bar, delta_display, styled, uncovered_display,
+    visible_delta_entries,
 };
 use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
 use crate::merge::CrapEntry;
@@ -15,6 +16,7 @@ use std::io::Write;
 pub(crate) fn render_human(
     entries: &[CrapEntry],
     threshold: f64,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     if entries.is_empty() {
@@ -22,7 +24,7 @@ pub(crate) fn render_human(
         return Ok(());
     }
     write_per_crate_human(entries, threshold, out)?;
-    let table = build_table(entries, threshold);
+    let table = build_table(entries, threshold, uncovered_hints);
     writeln!(out, "{table}")?;
     write_summary(
         out,
@@ -36,18 +38,23 @@ pub(crate) fn render_human(
 fn build_table(
     entries: &[CrapEntry],
     threshold: f64,
+    uncovered_hints: bool,
 ) -> Table {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     apply_table_styling(&mut table);
-    table.set_header(vec![
+    let mut header = vec![
         Cell::new("").add_attribute(Attribute::Bold),
         Cell::new("CRAP").add_attribute(Attribute::Bold),
         Cell::new("CC").add_attribute(Attribute::Bold),
         Cell::new("Coverage").add_attribute(Attribute::Bold),
         Cell::new("Function").add_attribute(Attribute::Bold),
         Cell::new("Location").add_attribute(Attribute::Bold),
-    ]);
+    ];
+    if uncovered_hints {
+        header.push(Cell::new("Uncovered").add_attribute(Attribute::Bold));
+    }
+    table.set_header(header);
     // Numeric columns read more naturally when right-aligned.
     table
         .column_mut(1)
@@ -58,7 +65,7 @@ fn build_table(
         .unwrap()
         .set_cell_alignment(CellAlignment::Right);
     for entry in entries {
-        table.add_row(build_row(entry, threshold));
+        table.add_row(build_row(entry, threshold, uncovered_hints));
     }
     table
 }
@@ -67,17 +74,22 @@ fn build_table(
 fn build_row(
     entry: &CrapEntry,
     threshold: f64,
+    uncovered_hints: bool,
 ) -> Vec<Cell> {
     let grade = Grade::of(entry.crap, threshold);
     let color = grade.color();
-    vec![
+    let mut row = vec![
         Cell::new(grade.icon()).fg(color),
         Cell::new(format!("{:.1}", entry.crap)).fg(color),
         Cell::new(entry.cyclomatic as usize),
         Cell::new(coverage_bar(entry.coverage)),
         Cell::new(&entry.function),
         Cell::new(format!("{}:{}", entry.file.display(), entry.line)),
-    ]
+    ];
+    if uncovered_hints {
+        row.push(Cell::new(uncovered_display(&entry.uncovered)));
+    }
+    row
 }
 
 /// Write the one-line summary (✓ or ✗) after the table.
@@ -112,6 +124,7 @@ pub(crate) fn render_delta_human(
     report: &DeltaReport,
     threshold: f64,
     show_unchanged: bool,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     if report.entries.is_empty() && report.removed.is_empty() {
@@ -122,7 +135,7 @@ pub(crate) fn render_delta_human(
     // Unchanged rows are hidden by default (spec 16); the summary line below
     // still counts every entry.
     let visible = visible_delta_entries(&report.entries, show_unchanged);
-    write_delta_body(report, &visible, threshold, out)?;
+    write_delta_body(report, &visible, threshold, uncovered_hints, out)?;
     write_delta_summary(out, report)
 }
 
@@ -132,13 +145,14 @@ fn write_delta_body(
     report: &DeltaReport,
     visible: &[&DeltaEntry],
     threshold: f64,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     if visible.is_empty() && report.removed.is_empty() {
         return writeln!(out, "No changes since baseline.").map_err(Into::into);
     }
     if !visible.is_empty() {
-        let table = build_delta_table(visible, threshold);
+        let table = build_delta_table(visible, threshold, uncovered_hints);
         writeln!(out, "{table}")?;
     }
     if !report.removed.is_empty() {
@@ -168,11 +182,12 @@ fn write_removed_section(
 fn build_delta_table(
     entries: &[&DeltaEntry],
     threshold: f64,
+    uncovered_hints: bool,
 ) -> Table {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     apply_table_styling(&mut table);
-    table.set_header(vec![
+    let mut header = vec![
         Cell::new("").add_attribute(Attribute::Bold),
         Cell::new("CRAP").add_attribute(Attribute::Bold),
         Cell::new("Δ").add_attribute(Attribute::Bold),
@@ -180,7 +195,11 @@ fn build_delta_table(
         Cell::new("Coverage").add_attribute(Attribute::Bold),
         Cell::new("Function").add_attribute(Attribute::Bold),
         Cell::new("Location").add_attribute(Attribute::Bold),
-    ]);
+    ];
+    if uncovered_hints {
+        header.push(Cell::new("Uncovered").add_attribute(Attribute::Bold));
+    }
+    table.set_header(header);
     table
         .column_mut(1)
         .unwrap()
@@ -194,7 +213,7 @@ fn build_delta_table(
         .unwrap()
         .set_cell_alignment(CellAlignment::Right);
     for de in entries.iter().copied() {
-        table.add_row(build_delta_row(de, threshold));
+        table.add_row(build_delta_row(de, threshold, uncovered_hints));
     }
     table
 }
@@ -202,6 +221,7 @@ fn build_delta_table(
 fn build_delta_row(
     de: &DeltaEntry,
     threshold: f64,
+    uncovered_hints: bool,
 ) -> Vec<Cell> {
     let e = &de.current;
     let grade = Grade::of(e.crap, threshold);
@@ -224,7 +244,7 @@ fn build_delta_row(
         .unwrap_or_default();
     let location = format!("{}:{}{prev_suffix}", e.file.display(), e.line);
 
-    vec![
+    let mut row = vec![
         Cell::new(grade.icon()).fg(color),
         Cell::new(format!("{:.1}", e.crap)).fg(color),
         delta_cell,
@@ -232,7 +252,11 @@ fn build_delta_row(
         Cell::new(coverage_bar(e.coverage)),
         Cell::new(&e.function),
         Cell::new(location),
-    ]
+    ];
+    if uncovered_hints {
+        row.push(Cell::new(uncovered_display(&e.uncovered)));
+    }
+    row
 }
 
 fn write_delta_summary(
@@ -299,6 +323,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: crate_name.map(std::string::ToString::to_string),
+            uncovered: Vec::new(),
         }
     }
 
@@ -322,6 +347,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&all_clean, &opts(30.0, Format::Human), &mut buf).unwrap();
@@ -369,6 +395,7 @@ mod tests {
             coverage: None,
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
@@ -387,6 +414,7 @@ mod tests {
             coverage: Some(44.4),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
@@ -406,6 +434,7 @@ mod tests {
                 coverage: Some(0.0),
                 crap: 72.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             CrapEntry {
                 file: PathBuf::from("a.rs"),
@@ -415,6 +444,7 @@ mod tests {
                 coverage: Some(0.0),
                 crap: 110.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
         ];
         let mut buf = Vec::new();
@@ -436,6 +466,7 @@ mod tests {
             coverage: Some(0.0),
             crap: 20.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::Human), &mut buf).unwrap();
@@ -485,6 +516,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(1.0),
             delta: Some(0.0),
@@ -501,7 +533,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_human(&report, 30.0, false, &mut buf).unwrap();
+        render_delta_human(&report, 30.0, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("↔ 1 moved"),
@@ -528,6 +560,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 50.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(40.0),
             delta: Some(10.0),
@@ -552,7 +585,7 @@ mod tests {
     #[test]
     fn delta_human_hides_unchanged_rows_by_default() {
         let mut buf = Vec::new();
-        render_delta_human(&mixed_report(), 30.0, false, &mut buf).unwrap();
+        render_delta_human(&mixed_report(), 30.0, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("reg"), "regressed row must appear:\n{s}");
         assert!(s.contains("imp"), "improved row must appear:\n{s}");
@@ -568,7 +601,7 @@ mod tests {
     #[test]
     fn delta_human_show_unchanged_restores_full_table() {
         let mut buf = Vec::new();
-        render_delta_human(&mixed_report(), 30.0, true, &mut buf).unwrap();
+        render_delta_human(&mixed_report(), 30.0, true, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         for f in ["reg", "imp", "u1", "u2", "u3"] {
             assert!(s.contains(f), "{f} must appear with --show-unchanged:\n{s}");
@@ -585,7 +618,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_human(&report, 30.0, false, &mut buf).unwrap();
+        render_delta_human(&report, 30.0, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("No changes since baseline."),
@@ -611,7 +644,7 @@ mod tests {
             }],
         };
         let mut buf = Vec::new();
-        render_delta_human(&report, 30.0, false, &mut buf).unwrap();
+        render_delta_human(&report, 30.0, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("Removed since baseline:") && s.contains("gone"),
@@ -621,5 +654,67 @@ mod tests {
             !s.contains("No changes since baseline."),
             "a removal is a change — must not print the quiet confirmation:\n{s}"
         );
+    }
+
+    // --- uncovered hints ----------------------------------------------------
+
+    #[test]
+    fn uncovered_hints_append_column_with_ranges() {
+        // Kills: dropping the header push, dropping the row-cell push.
+        let mut buf = Vec::new();
+        render_human(
+            &super::super::test_support::sample_with_uncovered(),
+            30.0,
+            true,
+            &mut buf,
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Uncovered"), "header column must appear:\n{s}");
+        assert!(s.contains("12–14, 18"), "range cell must appear:\n{s}");
+    }
+
+    #[test]
+    fn uncovered_hints_off_leaves_table_without_the_column() {
+        // Kills: inverting/hardcoding the uncovered_hints gate.
+        let mut buf = Vec::new();
+        render_human(
+            &super::super::test_support::sample_with_uncovered(),
+            30.0,
+            false,
+            &mut buf,
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(!s.contains("Uncovered"), "no header column when off:\n{s}");
+        assert!(!s.contains("12–14"), "no range cell when off:\n{s}");
+
+        // Byte-identity: with hints off, entries carrying ranges must render
+        // exactly like entries without them — ranges must not leak into any
+        // cell, padding, or column width.
+        let mut without = Vec::new();
+        render_human(
+            &super::super::test_support::sample(),
+            30.0,
+            false,
+            &mut without,
+        )
+        .unwrap();
+        assert_eq!(s, String::from_utf8(without).unwrap());
+    }
+
+    #[test]
+    fn uncovered_hints_render_in_the_delta_table() {
+        let mut de = delta_entry("reg", DeltaStatus::Regressed);
+        de.current.uncovered = vec![crate::coverage::LineRange { start: 7, end: 9 }];
+        let report = DeltaReport {
+            entries: vec![de],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_human(&report, 30.0, false, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Uncovered"), "delta header column:\n{s}");
+        assert!(s.contains("7–9"), "delta range cell:\n{s}");
     }
 }

--- a/src/report/human.rs
+++ b/src/report/human.rs
@@ -51,9 +51,7 @@ fn build_table(
         Cell::new("Function").add_attribute(Attribute::Bold),
         Cell::new("Location").add_attribute(Attribute::Bold),
     ];
-    if uncovered_hints {
-        header.push(Cell::new("Uncovered").add_attribute(Attribute::Bold));
-    }
+    header.extend(uncovered_hints.then(|| Cell::new("Uncovered").add_attribute(Attribute::Bold)));
     table.set_header(header);
     // Numeric columns read more naturally when right-aligned.
     table
@@ -86,9 +84,7 @@ fn build_row(
         Cell::new(&entry.function),
         Cell::new(format!("{}:{}", entry.file.display(), entry.line)),
     ];
-    if uncovered_hints {
-        row.push(Cell::new(uncovered_display(&entry.uncovered)));
-    }
+    row.extend(uncovered_hints.then(|| Cell::new(uncovered_display(&entry.uncovered))));
     row
 }
 
@@ -196,9 +192,7 @@ fn build_delta_table(
         Cell::new("Function").add_attribute(Attribute::Bold),
         Cell::new("Location").add_attribute(Attribute::Bold),
     ];
-    if uncovered_hints {
-        header.push(Cell::new("Uncovered").add_attribute(Attribute::Bold));
-    }
+    header.extend(uncovered_hints.then(|| Cell::new("Uncovered").add_attribute(Attribute::Bold)));
     table.set_header(header);
     table
         .column_mut(1)
@@ -253,9 +247,7 @@ fn build_delta_row(
         Cell::new(&e.function),
         Cell::new(location),
     ];
-    if uncovered_hints {
-        row.push(Cell::new(uncovered_display(&e.uncovered)));
-    }
+    row.extend(uncovered_hints.then(|| Cell::new(uncovered_display(&e.uncovered))));
     row
 }
 

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -186,6 +186,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "sha".into());
         let mut buf = Vec::new();

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -5,7 +5,10 @@
 
 use super::links::{SourceLinks, linkify};
 use super::per_crate::write_per_crate_markdown;
-use super::types::{Grade, delta_display, format_location_with_prev, visible_delta_entries};
+use super::types::{
+    Grade, delta_display, format_location_with_prev, uncovered_cell_suffix, visible_delta_entries,
+    write_abs_gfm_header, write_delta_gfm_header,
+};
 use super::write_pr_comment_marker;
 use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus};
 use crate::merge::CrapEntry;
@@ -54,10 +57,10 @@ fn write_markdown_entries_table(
     entries: &[CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
-    writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---|---|")?;
+    write_abs_gfm_header(out, uncovered_hints)?;
     for entry in entries {
         let grade = Grade::of(entry.crap, threshold);
         let cov = match entry.coverage {
@@ -78,13 +81,14 @@ fn write_markdown_entries_table(
         );
         writeln!(
             out,
-            "| {} | {:.1} | {} | {} | {} | {} |",
+            "| {} | {:.1} | {} | {} | {} | {} |{}",
             grade.icon(),
             entry.crap,
             entry.cyclomatic as usize,
             cov,
             func,
             loc,
+            uncovered_cell_suffix(uncovered_hints, &entry.uncovered),
         )?;
     }
     Ok(())
@@ -96,6 +100,7 @@ pub(crate) fn render_markdown(
     entries: &[CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -106,7 +111,7 @@ pub(crate) fn render_markdown(
     let crappy = super::crappy_count(entries, threshold);
     write_markdown_absolute_heading(crappy, threshold, out)?;
     write_per_crate_markdown(entries, threshold, out)?;
-    write_markdown_entries_table(entries, threshold, links, out)?;
+    write_markdown_entries_table(entries, threshold, links, uncovered_hints, out)?;
     write_markdown_absolute_summary(crappy, entries.len(), threshold, out)
 }
 
@@ -140,10 +145,10 @@ fn write_delta_entries_table(
     entries: &[&DeltaEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
-    writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
+    write_delta_gfm_header(out, uncovered_hints)?;
     for de in entries.iter().copied() {
         let e = &de.current;
         let grade = Grade::of(e.crap, threshold);
@@ -153,7 +158,7 @@ fn write_delta_entries_table(
         let loc = linkify(loc_text, links, &e.file, e.line);
         writeln!(
             out,
-            "| {} | {:.1} | {} | {} | {} | {} | {} |",
+            "| {} | {:.1} | {} | {} | {} | {} | {} |{}",
             grade.icon(),
             e.crap,
             delta_display(de),
@@ -161,6 +166,7 @@ fn write_delta_entries_table(
             cov,
             func,
             loc,
+            uncovered_cell_suffix(uncovered_hints, &e.uncovered),
         )?;
     }
     Ok(())
@@ -209,6 +215,7 @@ pub(crate) fn render_delta_markdown(
     threshold: f64,
     links: Option<&SourceLinks>,
     show_unchanged: bool,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -220,7 +227,7 @@ pub(crate) fn render_delta_markdown(
     // Unchanged rows are hidden by default (spec 16); the stats line below
     // still counts every entry.
     let visible = visible_delta_entries(&report.entries, show_unchanged);
-    write_markdown_delta_body(report, &visible, threshold, links, out)?;
+    write_markdown_delta_body(report, &visible, threshold, links, uncovered_hints, out)?;
     write_markdown_delta_stats(report, out)
 }
 
@@ -231,13 +238,14 @@ fn write_markdown_delta_body(
     visible: &[&DeltaEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     if visible.is_empty() && report.removed.is_empty() {
         return writeln!(out, "_No changes since baseline._").map_err(Into::into);
     }
     if !visible.is_empty() {
-        write_delta_entries_table(visible, threshold, links, out)?;
+        write_delta_entries_table(visible, threshold, links, uncovered_hints, out)?;
     }
     if !report.removed.is_empty() {
         write_markdown_removed(&report.removed, out)?;
@@ -261,6 +269,7 @@ mod tests {
             coverage: Some(50.0),
             crap: 5.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "main".into());
         let mut buf = Vec::new();
@@ -297,6 +306,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(1.0),
             delta: Some(0.0),
@@ -313,7 +323,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_markdown(&report, 30.0, None, false, &mut buf).unwrap();
+        render_delta_markdown(&report, 30.0, None, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("↔ 1 moved"),
@@ -342,6 +352,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(1.0),
             delta: Some(0.0),
@@ -357,6 +368,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(1.0),
             delta: Some(0.0),
@@ -368,7 +380,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_markdown(&report, 30.0, None, true, &mut buf).unwrap();
+        render_delta_markdown(&report, 30.0, None, true, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("`src/a.rs:7`"),
@@ -395,6 +407,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 50.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(40.0),
             delta: Some(10.0),
@@ -416,7 +429,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_markdown(&report, 30.0, None, false, &mut buf).unwrap();
+        render_delta_markdown(&report, 30.0, None, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("reg"), "regressed row must appear:\n{s}");
         assert!(!s.contains("u1"), "unchanged rows must be hidden:\n{s}");
@@ -437,7 +450,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_markdown(&report, 30.0, None, true, &mut buf).unwrap();
+        render_delta_markdown(&report, 30.0, None, true, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("reg") && s.contains("u1"),
@@ -453,7 +466,7 @@ mod tests {
             removed: vec![],
         };
         let mut buf = Vec::new();
-        render_delta_markdown(&report, 30.0, None, false, &mut buf).unwrap();
+        render_delta_markdown(&report, 30.0, None, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(
             s.contains("_No changes since baseline._"),
@@ -463,5 +476,69 @@ mod tests {
             s.contains("· 1 unchanged"),
             "stats line still printed with full counts:\n{s}"
         );
+    }
+
+    // --- uncovered hints ----------------------------------------------------
+
+    #[test]
+    fn uncovered_hints_extend_header_and_rows() {
+        // Kills: dropping the header suffix, dropping the cell suffix.
+        let entries = super::super::test_support::sample_with_uncovered();
+        let mut buf = Vec::new();
+        render_markdown(&entries, 30.0, None, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("| | CRAP | CC | Cov % | Function | Location | Uncovered |"),
+            "extended header:\n{s}"
+        );
+        assert!(
+            s.contains("|---|---:|---:|---:|---|---|---|"),
+            "extended separator:\n{s}"
+        );
+        assert!(s.contains("| 12–14, 18 |"), "range cell:\n{s}");
+    }
+
+    #[test]
+    fn uncovered_hints_off_keep_tables_byte_identical() {
+        // Pins the spec clause "output is byte-identical to today's": the
+        // golden literal is the pre-hint markdown output, so ANY off-state
+        // drift fails — not just drift containing the string "Uncovered".
+        // Kills: inverting/hardcoding the uncovered_hints gate, stray
+        // suffix cells or separator arity in the off state.
+        let entries = super::super::test_support::sample_with_uncovered();
+        let mut buf = Vec::new();
+        render_markdown(&entries, 30.0, None, false, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            s,
+            "<!-- cargo-crap-report -->\n\
+             \n\
+             ## ⚠️ 1 function(s) exceed CRAP threshold 30\n\
+             \n\
+             | | CRAP | CC | Cov % | Function | Location |\n\
+             |---|---:|---:|---:|---|---|\n\
+             | ✓ | 1.0 | 1 | 100.0 | `clean` | `a.rs:1` |\n\
+             | ✗ | 110.0 | 10 | 0.0 | `crappy` | `a.rs:10` |\n\
+             \n\
+             ✗ 1/2 function(s) exceed CRAP threshold 30.\n"
+        );
+    }
+
+    #[test]
+    fn uncovered_hints_extend_the_delta_table() {
+        let mut de = delta_entry("f", DeltaStatus::Regressed);
+        de.current.uncovered = vec![crate::coverage::LineRange { start: 7, end: 9 }];
+        let report = DeltaReport {
+            entries: vec![de],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_markdown(&report, 30.0, None, false, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("| | CRAP | Δ | CC | Cov % | Function | Location | Uncovered |"),
+            "extended delta header:\n{s}"
+        );
+        assert!(s.contains("| 7–9 |"), "delta range cell:\n{s}");
     }
 }

--- a/src/report/per_crate.rs
+++ b/src/report/per_crate.rs
@@ -126,6 +126,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: crate_name.map(std::string::ToString::to_string),
+            uncovered: Vec::new(),
         }
     }
 

--- a/src/report/pr_comment.rs
+++ b/src/report/pr_comment.rs
@@ -9,7 +9,9 @@
 //! artifacts.
 
 use super::links::{SourceLinks, linkify};
-use super::types::{Grade, delta_display};
+use super::types::{
+    Grade, delta_display, uncovered_cell_suffix, write_abs_gfm_header, write_delta_gfm_header,
+};
 use super::write_pr_comment_marker;
 use crate::delta::{DeltaEntry, DeltaReport, DeltaStatus, RemovedEntry};
 use crate::merge::CrapEntry;
@@ -92,6 +94,7 @@ fn write_pr_comment_row(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     let e = &de.current;
     let grade = Grade::of(e.crap, threshold);
@@ -107,7 +110,7 @@ fn write_pr_comment_row(
     let loc = linkify(loc_inner, links, &e.file, e.line);
     writeln!(
         out,
-        "| {} | {:.1} | {} | {} | {} | {} | {} |",
+        "| {} | {:.1} | {} | {} | {} | {} | {} |{}",
         grade.icon(),
         e.crap,
         delta_display(de),
@@ -115,6 +118,7 @@ fn write_pr_comment_row(
         cov,
         func,
         loc,
+        uncovered_cell_suffix(uncovered_hints, &e.uncovered),
     )?;
     Ok(())
 }
@@ -126,6 +130,7 @@ fn write_pr_comment_abs_row(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     let grade = Grade::of(e.crap, threshold);
     let cov = e.coverage.map_or("—".to_string(), |p| format!("{p:.1}"));
@@ -134,13 +139,14 @@ fn write_pr_comment_abs_row(
     let loc = linkify(format!("`{loc_text}:{}`", e.line), links, &e.file, e.line);
     writeln!(
         out,
-        "| {} | {:.1} | {} | {} | {} | {} |",
+        "| {} | {:.1} | {} | {} | {} | {} |{}",
         grade.icon(),
         e.crap,
         e.cyclomatic as usize,
         cov,
         func,
         loc,
+        uncovered_cell_suffix(uncovered_hints, &e.uncovered),
     )?;
     Ok(())
 }
@@ -303,21 +309,21 @@ fn write_pr_comment_primary(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     let total = b.regressed.len() + b.new_entries.len();
     if total == 0 {
         return Ok(());
     }
     writeln!(out)?;
-    writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
+    write_delta_gfm_header(out, uncovered_hints)?;
     for de in b
         .regressed
         .iter()
         .chain(b.new_entries.iter())
         .take(MAX_ROWS_PER_SECTION)
     {
-        write_pr_comment_row(out, de, threshold, prefix, links)?;
+        write_pr_comment_row(out, de, threshold, prefix, links, uncovered_hints)?;
     }
     write_truncation_if_capped(out, total)
 }
@@ -328,6 +334,7 @@ fn write_pr_comment_improved_section(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     if b.improved.is_empty() {
         return Ok(());
@@ -339,10 +346,9 @@ fn write_pr_comment_improved_section(
         b.improved.len()
     )?;
     writeln!(out)?;
-    writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
+    write_delta_gfm_header(out, uncovered_hints)?;
     for de in b.improved.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_row(out, de, threshold, prefix, links)?;
+        write_pr_comment_row(out, de, threshold, prefix, links, uncovered_hints)?;
     }
     write_truncation_if_capped(out, b.improved.len())?;
     writeln!(out)?;
@@ -359,6 +365,7 @@ fn write_pr_comment_moved_section(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     if b.moved.is_empty() {
         return Ok(());
@@ -366,10 +373,9 @@ fn write_pr_comment_moved_section(
     writeln!(out)?;
     writeln!(out, "<details><summary>↔ {} moved</summary>", b.moved.len())?;
     writeln!(out)?;
-    writeln!(out, "| | CRAP | Δ | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---:|---|---|")?;
+    write_delta_gfm_header(out, uncovered_hints)?;
     for de in b.moved.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_row(out, de, threshold, prefix, links)?;
+        write_pr_comment_row(out, de, threshold, prefix, links, uncovered_hints)?;
     }
     write_truncation_if_capped(out, b.moved.len())?;
     writeln!(out)?;
@@ -383,6 +389,7 @@ fn write_pr_comment_hot_spots_section(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     if b.hot_spots.is_empty() {
         return Ok(());
@@ -393,10 +400,9 @@ fn write_pr_comment_hot_spots_section(
         "<details><summary>🔥 Top hot spots above threshold</summary>"
     )?;
     writeln!(out)?;
-    writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---|---|")?;
+    write_abs_gfm_header(out, uncovered_hints)?;
     for de in b.hot_spots.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_abs_row(out, &de.current, threshold, prefix, links)?;
+        write_pr_comment_abs_row(out, &de.current, threshold, prefix, links, uncovered_hints)?;
     }
     write_truncation_if_capped(out, b.hot_spots.len())?;
     writeln!(out)?;
@@ -447,6 +453,7 @@ pub(crate) fn render_delta_pr_comment(
     report: &DeltaReport,
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -458,8 +465,8 @@ pub(crate) fn render_delta_pr_comment(
     let prefix = buckets.common_prefix();
     write_pr_comment_delta_headline(out, buckets.regressed.len())?;
     write_pr_comment_breakdown(out, &buckets, unchanged_count(report))?;
-    write_pr_comment_primary(out, &buckets, threshold, &prefix, links)?;
-    write_pr_comment_secondary_sections(out, &buckets, threshold, &prefix, links)
+    write_pr_comment_primary(out, &buckets, threshold, &prefix, links, uncovered_hints)?;
+    write_pr_comment_secondary_sections(out, &buckets, threshold, &prefix, links, uncovered_hints)
 }
 
 /// Emit the four secondary sections (Improved / Moved / Hot spots /
@@ -472,10 +479,11 @@ fn write_pr_comment_secondary_sections(
     threshold: f64,
     prefix: &Path,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
-    write_pr_comment_improved_section(out, buckets, threshold, prefix, links)?;
-    write_pr_comment_moved_section(out, buckets, threshold, prefix, links)?;
-    write_pr_comment_hot_spots_section(out, buckets, threshold, prefix, links)?;
+    write_pr_comment_improved_section(out, buckets, threshold, prefix, links, uncovered_hints)?;
+    write_pr_comment_moved_section(out, buckets, threshold, prefix, links, uncovered_hints)?;
+    write_pr_comment_hot_spots_section(out, buckets, threshold, prefix, links, uncovered_hints)?;
     write_pr_comment_removed_section(out, buckets, prefix)
 }
 
@@ -510,6 +518,7 @@ fn write_pr_comment_abs_table(
     above: &[&CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
 ) -> Result<()> {
     if above.is_empty() {
         return Ok(());
@@ -517,10 +526,9 @@ fn write_pr_comment_abs_table(
     let paths: Vec<PathBuf> = above.iter().map(|e| e.file.clone()).collect();
     let prefix = compute_render_prefix(&paths);
     writeln!(out)?;
-    writeln!(out, "| | CRAP | CC | Cov % | Function | Location |")?;
-    writeln!(out, "|---|---:|---:|---:|---|---|")?;
+    write_abs_gfm_header(out, uncovered_hints)?;
     for e in above.iter().take(MAX_ROWS_PER_SECTION) {
-        write_pr_comment_abs_row(out, e, threshold, &prefix, links)?;
+        write_pr_comment_abs_row(out, e, threshold, &prefix, links, uncovered_hints)?;
     }
     write_truncation_if_capped(out, above.len())
 }
@@ -529,6 +537,7 @@ pub(crate) fn render_pr_comment(
     entries: &[CrapEntry],
     threshold: f64,
     links: Option<&SourceLinks>,
+    uncovered_hints: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     write_pr_comment_marker(out)?;
@@ -543,7 +552,7 @@ pub(crate) fn render_pr_comment(
         entries.len()
     )?;
     let above = above_threshold_sorted(entries, threshold);
-    write_pr_comment_abs_table(out, &above, threshold, links)
+    write_pr_comment_abs_table(out, &above, threshold, links, uncovered_hints)
 }
 
 #[cfg(test)]
@@ -568,6 +577,7 @@ mod tests {
                 coverage: Some(80.0),
                 crap,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: baseline,
             delta: baseline.map(|b| crap - b),
@@ -578,7 +588,7 @@ mod tests {
 
     fn render_delta_pr_to_string(report: &DeltaReport) -> String {
         let mut buf = Vec::new();
-        render_delta_pr_comment(report, 30.0, None, &mut buf).unwrap();
+        render_delta_pr_comment(report, 30.0, None, false, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -587,7 +597,7 @@ mod tests {
         links: &SourceLinks,
     ) -> String {
         let mut buf = Vec::new();
-        render_delta_pr_comment(report, 30.0, Some(links), &mut buf).unwrap();
+        render_delta_pr_comment(report, 30.0, Some(links), false, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -1065,6 +1075,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
@@ -1082,6 +1093,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
@@ -1125,6 +1137,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 29.9,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             CrapEntry {
                 file: PathBuf::from("src/a.rs"),
@@ -1134,6 +1147,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 30.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             CrapEntry {
                 file: PathBuf::from("src/a.rs"),
@@ -1143,6 +1157,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 30.1,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
         ];
         let mut buf = Vec::new();
@@ -1174,6 +1189,7 @@ mod tests {
             coverage: Some(0.0),
             crap: 110.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let mut buf = Vec::new();
         render(&entries, &opts(30.0, Format::PrComment), &mut buf).unwrap();
@@ -1476,6 +1492,7 @@ mod tests {
             coverage: Some(0.0),
             crap: 110.0,
             crate_name: None,
+            uncovered: Vec::new(),
         }];
         let links = SourceLinks::new("https://github.com/o/r".into(), "abc".into());
         let mut buf = Vec::new();
@@ -1490,5 +1507,50 @@ mod tests {
             s.contains("[`very_crappy`](https://github.com/o/r/blob/abc/src/a.rs#L42)"),
             "absolute pr-comment must link Function:\n{s}"
         );
+    }
+
+    // --- uncovered hints ----------------------------------------------------
+
+    #[test]
+    fn uncovered_hints_extend_the_absolute_table() {
+        // Kills: dropping the header suffix or cell suffix in the abs path.
+        let entries = super::super::test_support::sample_with_uncovered();
+        let mut buf = Vec::new();
+        render_pr_comment(&entries, 30.0, None, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("| | CRAP | CC | Cov % | Function | Location | Uncovered |"),
+            "extended header:\n{s}"
+        );
+        assert!(s.contains("| 12–14, 18 |"), "range cell:\n{s}");
+    }
+
+    #[test]
+    fn uncovered_hints_off_keep_the_absolute_table_unchanged() {
+        // Kills: inverting/hardcoding the uncovered_hints gate.
+        let entries = super::super::test_support::sample_with_uncovered();
+        let mut buf = Vec::new();
+        render_pr_comment(&entries, 30.0, None, false, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(!s.contains("Uncovered"), "no column when off:\n{s}");
+        assert!(!s.contains("12–14"), "no cell when off:\n{s}");
+    }
+
+    #[test]
+    fn uncovered_hints_extend_the_delta_primary_table() {
+        let mut de = delta_entry("src/a.rs", "reg", 50.0, Some(40.0), DeltaStatus::Regressed);
+        de.current.uncovered = vec![crate::coverage::LineRange { start: 7, end: 9 }];
+        let report = DeltaReport {
+            entries: vec![de],
+            removed: vec![],
+        };
+        let mut buf = Vec::new();
+        render_delta_pr_comment(&report, 30.0, None, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("| | CRAP | Δ | CC | Cov % | Function | Location | Uncovered |"),
+            "extended delta header:\n{s}"
+        );
+        assert!(s.contains("| 7–9 |"), "delta range cell:\n{s}");
     }
 }

--- a/src/report/shields.rs
+++ b/src/report/shields.rs
@@ -183,6 +183,7 @@ mod tests {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         });
         let report = compute_delta(&entries, &baseline, 0.01);
 

--- a/src/report/summary.rs
+++ b/src/report/summary.rs
@@ -120,6 +120,7 @@ mod tests {
             coverage: Some(100.0),
             crap,
             crate_name: crate_name.map(std::string::ToString::to_string),
+            uncovered: Vec::new(),
         }
     }
 
@@ -188,6 +189,7 @@ mod tests {
                 coverage: Some(100.0),
                 crap: 1.0,
                 crate_name: None,
+                uncovered: Vec::new(),
             },
             baseline_crap: Some(1.0),
             delta: Some(0.0),

--- a/src/report/test_support.rs
+++ b/src/report/test_support.rs
@@ -5,6 +5,7 @@
 //! here.
 
 use super::{Format, RenderOptions};
+use crate::coverage::LineRange;
 use crate::merge::CrapEntry;
 use std::path::PathBuf;
 
@@ -35,6 +36,7 @@ pub(crate) fn sample() -> Vec<CrapEntry> {
             coverage: Some(100.0),
             crap: 1.0,
             crate_name: None,
+            uncovered: Vec::new(),
         },
         CrapEntry {
             file: PathBuf::from("a.rs"),
@@ -44,6 +46,20 @@ pub(crate) fn sample() -> Vec<CrapEntry> {
             coverage: Some(0.0),
             crap: 110.0,
             crate_name: None,
+            uncovered: Vec::new(),
         },
     ]
+}
+
+/// [`sample`] with uncovered ranges on the crappy entry — for the
+/// uncovered-hints rendering tests in the human / markdown / `pr_comment`
+/// submodules. Kept separate so `sample()`-based byte-level expectations
+/// stay untouched.
+pub(crate) fn sample_with_uncovered() -> Vec<CrapEntry> {
+    let mut entries = sample();
+    entries[1].uncovered = vec![
+        LineRange { start: 12, end: 14 },
+        LineRange { start: 18, end: 18 },
+    ];
+    entries
 }

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -3,7 +3,9 @@
 //! - [`Grade`]: three-tier severity classification driving icon/colour.
 //! - [`coverage_bar`]: 10-block ASCII bar for human tables.
 //! - [`delta_display`]: Δ-column text for delta rows.
+//! - [`uncovered_display`]: capped Uncovered-column text.
 
+use crate::coverage::LineRange;
 use crate::delta::{DeltaEntry, DeltaStatus};
 use comfy_table::Color;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -105,6 +107,89 @@ pub(crate) fn coverage_bar(pct: Option<f64>) -> String {
             )
         },
     }
+}
+
+/// How many uncovered ranges the human/markdown/pr-comment cell shows
+/// before collapsing the tail into `+N more`. JSON is uncapped.
+const UNCOVERED_DISPLAY_CAP: usize = 3;
+
+/// Format an Uncovered cell: en-dash ranges, comma-separated, capped at
+/// [`UNCOVERED_DISPLAY_CAP`] with a `+N more` tail. Single-line ranges
+/// render as a bare number (`17`, not `17–17`); no ranges render as an
+/// empty cell.
+pub(crate) fn uncovered_display(ranges: &[LineRange]) -> String {
+    let shown: Vec<String> = ranges
+        .iter()
+        .take(UNCOVERED_DISPLAY_CAP)
+        .map(|r| {
+            if r.start == r.end {
+                r.start.to_string()
+            } else {
+                format!("{}–{}", r.start, r.end)
+            }
+        })
+        .collect();
+    let hidden = ranges.len().saturating_sub(UNCOVERED_DISPLAY_CAP);
+    if hidden > 0 {
+        format!("{} +{hidden} more", shown.join(", "))
+    } else {
+        shown.join(", ")
+    }
+}
+
+/// Header/separator cell suffixes for the optional Uncovered column in the
+/// GFM tables (markdown / pr-comment). Returns `("", "")` when hints are
+/// off so every header literal stays byte-identical to the pre-hint output.
+pub(crate) fn uncovered_header_suffix(uncovered_hints: bool) -> (&'static str, &'static str) {
+    if uncovered_hints {
+        (" Uncovered |", "---|")
+    } else {
+        ("", "")
+    }
+}
+
+/// Row-cell suffix matching [`uncovered_header_suffix`]: the formatted
+/// Uncovered cell when hints are on, empty otherwise.
+pub(crate) fn uncovered_cell_suffix(
+    uncovered_hints: bool,
+    ranges: &[LineRange],
+) -> String {
+    if uncovered_hints {
+        format!(" {} |", uncovered_display(ranges))
+    } else {
+        String::new()
+    }
+}
+
+/// Write the GFM header + separator shared by every absolute table
+/// (markdown entries table, pr-comment hot spots and absolute table).
+/// One writer so header and row arity can't drift between call sites.
+pub(crate) fn write_abs_gfm_header(
+    out: &mut dyn std::io::Write,
+    uncovered_hints: bool,
+) -> anyhow::Result<()> {
+    let (head_extra, sep_extra) = uncovered_header_suffix(uncovered_hints);
+    writeln!(
+        out,
+        "| | CRAP | CC | Cov % | Function | Location |{head_extra}"
+    )?;
+    writeln!(out, "|---|---:|---:|---:|---|---|{sep_extra}")?;
+    Ok(())
+}
+
+/// Write the GFM header + separator shared by every delta table (markdown
+/// delta table, pr-comment primary / improved / moved sections).
+pub(crate) fn write_delta_gfm_header(
+    out: &mut dyn std::io::Write,
+    uncovered_hints: bool,
+) -> anyhow::Result<()> {
+    let (head_extra, sep_extra) = uncovered_header_suffix(uncovered_hints);
+    writeln!(
+        out,
+        "| | CRAP | Δ | CC | Cov % | Function | Location |{head_extra}"
+    )?;
+    writeln!(out, "|---|---:|---:|---:|---:|---|---|{sep_extra}")?;
+    Ok(())
 }
 
 /// Select the delta entries that should appear as table rows (spec 16).
@@ -235,5 +320,69 @@ mod tests {
             "✗",
             "just above threshold → Crappy"
         );
+    }
+
+    // --- uncovered_display ---
+
+    #[test]
+    fn uncovered_display_uses_en_dash_ranges_and_bare_singles() {
+        // Kills: swapping start/end, rendering `17–17` instead of `17`,
+        // wrong separator.
+        assert_eq!(
+            uncovered_display(&LineRange::list(&[(12, 14), (17, 17)])),
+            "12–14, 17"
+        );
+    }
+
+    #[test]
+    fn uncovered_display_is_empty_for_no_ranges() {
+        assert_eq!(uncovered_display(&[]), "");
+    }
+
+    #[test]
+    fn uncovered_display_caps_at_three_and_counts_the_rest() {
+        // Kills: cap off-by-one, dropping the `+N more` tail, wrong count.
+        assert_eq!(
+            uncovered_display(&LineRange::list(&[
+                (1, 2),
+                (4, 5),
+                (7, 8),
+                (10, 11),
+                (13, 14)
+            ])),
+            "1–2, 4–5, 7–8 +2 more"
+        );
+    }
+
+    #[test]
+    fn uncovered_display_shows_exactly_three_without_tail() {
+        // Kills: `> cap` replaced with `>= cap` (a spurious `+0 more`).
+        assert_eq!(
+            uncovered_display(&LineRange::list(&[(1, 2), (4, 5), (7, 8)])),
+            "1–2, 4–5, 7–8"
+        );
+    }
+
+    // --- uncovered_header_suffix / uncovered_cell_suffix ---
+
+    #[test]
+    fn uncovered_suffixes_are_empty_when_hints_are_off() {
+        // Off must be byte-identical to the pre-hint output.
+        assert_eq!(uncovered_header_suffix(false), ("", ""));
+        assert_eq!(
+            uncovered_cell_suffix(false, &LineRange::list(&[(1, 2)])),
+            ""
+        );
+    }
+
+    #[test]
+    fn uncovered_suffixes_extend_the_gfm_row_when_hints_are_on() {
+        // Kills: mismatched header/separator arity, missing cell padding.
+        assert_eq!(uncovered_header_suffix(true), (" Uncovered |", "---|"));
+        assert_eq!(
+            uncovered_cell_suffix(true, &LineRange::list(&[(1, 2)])),
+            " 1–2 |"
+        );
+        assert_eq!(uncovered_cell_suffix(true, &[]), "  |");
     }
 }

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -217,12 +217,25 @@ pub(crate) fn visible_delta_entries(
 /// (Moved = "no meaningful score change").
 pub(crate) fn delta_display(de: &DeltaEntry) -> String {
     match de.status {
-        DeltaStatus::Regressed | DeltaStatus::Improved => {
-            format!("{:+.1}", de.delta.unwrap())
-        },
+        DeltaStatus::Regressed | DeltaStatus::Improved => signed_delta(de.delta.unwrap()),
         DeltaStatus::New => "NEW".to_string(),
         DeltaStatus::Unchanged | DeltaStatus::Moved => String::new(),
     }
+}
+
+/// Format a signed Δ value, widening the precision until it stops rounding
+/// to zero. A Regressed/Improved delta is by definition non-zero (it beat
+/// the epsilon), so displaying it as `-0.0` misreports a real change; a
+/// score that moved by 0.04 shows as `-0.04`, not `-0.0`. Capped at three
+/// decimals — an epsilon small enough to defeat that is pathological.
+fn signed_delta(delta: f64) -> String {
+    for decimals in 1..=3 {
+        let s = format!("{delta:+.decimals$}");
+        if s.bytes().any(|b| b.is_ascii_digit() && b != b'0') {
+            return s;
+        }
+    }
+    format!("{delta:+.3}")
 }
 
 /// Render a Location-cell string, optionally appending `← <prev>` when the
@@ -320,6 +333,31 @@ mod tests {
             "✗",
             "just above threshold → Crappy"
         );
+    }
+
+    // --- signed_delta ---
+
+    #[test]
+    fn signed_delta_uses_one_decimal_for_ordinary_deltas() {
+        // Kills: starting the precision search above 1.
+        assert_eq!(signed_delta(1.0), "+1.0");
+        assert_eq!(signed_delta(-12.34), "-12.3");
+    }
+
+    #[test]
+    fn signed_delta_widens_until_the_value_is_visible() {
+        // A real change must never display as ±0.0 (kills: dropping the
+        // widening loop, off-by-one in the digit check).
+        assert_eq!(signed_delta(-0.04), "-0.04");
+        assert_eq!(signed_delta(0.04), "+0.04");
+        assert_eq!(signed_delta(-0.004), "-0.004");
+    }
+
+    #[test]
+    fn signed_delta_caps_at_three_decimals() {
+        // Sub-milli deltas fall back to the 3-decimal cap instead of
+        // widening forever.
+        assert_eq!(signed_delta(-0.0004), "-0.000");
     }
 
     // --- uncovered_display ---

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4176,3 +4176,77 @@ fn ambiguous_lcov_suffixes_bind_deterministically() {
         "byte-identical inputs, byte-identical output"
     );
 }
+
+// --- uncovered-span hints ---
+
+#[test]
+fn json_entries_carry_uncovered_ranges_for_partially_covered_functions() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let entries = parse_entries(&stdout);
+    let crappy = entries
+        .as_array()
+        .expect("entries array")
+        .iter()
+        .find(|e| e["function"] == "crappy")
+        .expect("crappy entry present");
+    let ranges = crappy["uncovered"].as_array().expect("uncovered array");
+    assert!(
+        !ranges.is_empty(),
+        "a 0%-covered function must carry uncovered ranges, got: {crappy}"
+    );
+    assert!(
+        ranges[0]["start"].is_u64() && ranges[0]["end"].is_u64(),
+        "ranges are start/end objects, got: {ranges:?}"
+    );
+}
+
+#[test]
+fn uncovered_hints_config_key_adds_column_to_human_output() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".cargo-crap.toml"),
+        "uncovered-hints = true\n",
+    )
+    .expect("write config");
+    let path_arg = std::fs::canonicalize(fixture_src()).expect("canonicalize fixture src");
+    let lcov_arg = std::fs::canonicalize(fixture_lcov()).expect("canonicalize fixture lcov");
+
+    let output = cmd()
+        .current_dir(dir.path())
+        .arg("--path")
+        .arg(&path_arg)
+        .arg("--lcov")
+        .arg(&lcov_arg)
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    assert!(
+        stdout.contains("Uncovered"),
+        "config `uncovered-hints = true` must add the column:\n{stdout}"
+    );
+}
+
+#[test]
+fn uncovered_hints_default_off_keeps_human_output_unchanged() {
+    let output = cmd()
+        .arg("--path")
+        .arg(fixture_src())
+        .arg("--lcov")
+        .arg(fixture_lcov())
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    assert!(
+        !stdout.contains("Uncovered"),
+        "without the config key the column must not appear:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements spec 28: each report entry gains a list of **uncovered line ranges** — maximal runs of instrumented-but-never-hit lines inside the function's span — turning the report from a scoreboard into a to-do list: you see exactly which lines to write tests for.

- `FileCoverage::uncovered_ranges_in_span` (sibling of `coverage_in_span`): one pass over the `DA` records; only a *covered* line splits a run, non-instrumented gaps coalesce, endpoints always land on instrumented lines.
- `CrapEntry.uncovered: Vec<LineRange>` — additive serde field (`default` + `skip_serializing_if`), so pre-existing baselines load unchanged and delta matching is untouched. Files absent from the LCOV report get **no** ranges even under `--missing pessimistic`: "unknown" stays distinguishable from "known-uncovered".
- Rendering is gated by a **config-only** key `uncovered-hints` (no CLI flag): human, markdown, and pr-comment gain an `Uncovered` column (`12–14, 18`, capped at 3 ranges + `+N more`). JSON always carries the full ranges. With the key off, output is byte-identical to before — pinned by a golden test.
- Both JSON schemas (`report-v1`, `delta-v2`) gain the `uncovered` / `LineRange` definitions (they enforce `additionalProperties: false`, so this is load-bearing).
- Spec 28 committed alongside, plus status corrections for specs 23–26 (all verified implemented).

## Testing

- `just dev` clean: fmt, clippy `-D warnings`, 470 tests, dogfood run (193 functions, none above threshold 15).
- `just dev-mutants-diff` clean: 463 mutants — 427 caught, 36 unviable, 0 missed.
- New coverage: range-computation unit tests, serde round-trip + pre-field baseline compat, on/off rendering tests per format (including byte-identity goldens), config key parsing (kebab + snake alias), and three end-to-end CLI tests.