### PR TITLE
chore: adopt the Keeler spec-first workflow

### DIFF
--- a/.claude/commands/keeler/feature.md
+++ b/.claude/commands/keeler/feature.md
@@ -1,0 +1,18 @@
+---
+description: Run the full feature pipeline — spec → tasks → TDD → QA → review → mutants
+argument-hint: <problem description>
+---
+
+Problem: $ARGUMENTS
+
+Orchestrate the full workflow from .claude/keeler.md for this problem, stage by stage. Each stage follows its command's instructions exactly (`.claude/commands/keeler/<stage>.md`):
+
+0. **Baseline** — run `just crap-baseline` to snapshot the current CRAP scores; the final QA will diff against it.
+1. **Spec** — follow /keeler:spec: analyze the problem, ask clarifying questions, draft `specs/NN-<slug>.md`. **Hard stop: wait for the user to approve the spec.** Do not proceed on your own.
+2. **Tasks** — follow /keeler:tasks: break the approved spec into TDD tasks with scenario mapping.
+3. **TDD** — follow /keeler:tdd for each task in order: red → green → refactor, one task at a time. Give a one-line progress update per completed task.
+4. **QA** — follow /keeler:qa: `just dev`, coverage inspection, results table.
+5. **Review** — follow /keeler:review: spec conformance, correctness, test quality, simplification. Present findings to the user; apply agreed fixes via the /keeler:tdd discipline and re-run /keeler:qa.
+6. **Mutants** — follow /keeler:mutants: mutation tests on changed files; strengthen tests and loop (tests → /keeler:qa → mutants) until zero survivors.
+
+Finish with a summary: spec file, tasks completed, tests added (unit/property/acceptance counts), coverage, worst CRAP score, the CRAP delta vs the stage-0 baseline (regressed/improved/new), mutation results per round, and review findings with their resolutions.

--- a/.claude/commands/keeler/fix.md
+++ b/.claude/commands/keeler/fix.md
@@ -1,0 +1,16 @@
+---
+description: Bugfix pipeline — reproduce with a failing test first, then fix minimally
+argument-hint: <bug description or failing behavior>
+---
+
+Bug to fix: $ARGUMENTS
+
+You are on the **bugfix path** (see .claude/keeler.md § Change classes). No spec is drafted for a bug — but the discipline is stricter in one way: **no fix may be written before the bug is reproduced by a failing test.**
+
+1. **Understand & reproduce.** Restate the bug: expected vs actual behavior. Write a regression test that fails on the current code — named after the bug's behavior, placed where it belongs (unit test next to the code, or acceptance test if the bug is user-observable). Run it and **show it failing for the right reason**. If you cannot reproduce, stop and report — never "fix" what you can't observe.
+2. **Check the spec.** Find the spec covering this behavior:
+   - If the bug **contradicts an approved scenario** — it's a plain defect; the scenario is your oracle.
+   - If the spec is **silent** (the bug lives in unspecified behavior) — propose a one-scenario spec amendment and wait for approval before fixing; the fix would otherwise encode an undecided requirement.
+3. **Fix minimally.** The smallest change that makes the regression test pass without breaking others. Resist drive-by refactoring — if you see unrelated debt, note it in the summary instead.
+4. **Gates.** Run `just dev`, then `just mutants-diff`. Surviving mutants on the fixed lines mean the regression test is weaker than it looks — strengthen it (see /keeler:mutants).
+5. **Report** (English, per .claude/keeler.md): the reproduction, root cause, the fix, gate results, and anything discovered along the way. Do not commit without confirmation.

--- a/.claude/commands/keeler/mutants.md
+++ b/.claude/commands/keeler/mutants.md
@@ -1,0 +1,22 @@
+---
+description: Mutation-test changed files; strengthen tests until zero survivors
+argument-hint: <file to mutate; empty = files changed vs HEAD>
+---
+
+Target: $ARGUMENTS (if empty, run `just mutants-diff` for files changed vs HEAD; with a file argument, `just mutants <file>`).
+
+You are in the **mutation testing stage** (see .claude/keeler.md) — the final gate. A surviving mutant means the test suite would not notice that bug. **The fix is always a stronger test, never a code change to appease the tool** (unless the mutant reveals genuinely dead code — then propose removing it).
+
+1. Run the mutation tests. Read `mutants.out/outcomes.json` / the summary for results.
+2. **If zero mutants survived (and none timed out unexpectedly): set the spec's `Status:` to `Implemented`, report the numbers, and close with status PASS.** Mutants are Keeler's control questions — a planted lie the sensors must catch; a survivor means the instrument (the test suite) can't be trusted yet, and the status stays FAIL until it can.
+3. For each surviving mutant:
+   - explain what the mutation was and why no test caught it (missing assertion? untested branch? weak property?),
+   - write a test that kills it — test-first: add the test, confirm it passes on real code, and reason about why it would fail on the mutant,
+   - prefer strengthening an existing property test's invariant over adding a narrow example test when the survivor points at a general gap.
+4. After strengthening tests, re-run the loop as .claude/keeler.md requires:
+   - `just dev` (fmt, lint, tests, coverage, CRAP — the new tests changed coverage),
+   - the same mutation run again.
+5. Repeat until zero survivors. Then report: total mutants, caught/survived per round, which tests were added, and final gate status.
+6. **Tick the task's checkbox** in the spec's Tasks section. This is the end of the pipeline, so this is the stage that can honestly say the task is done — tdd → qa → review → mutants all ran.
+
+Then, and only then, move to the next task with `/keeler:tdd`.

--- a/.claude/commands/keeler/qa.md
+++ b/.claude/commands/keeler/qa.md
@@ -1,0 +1,24 @@
+---
+description: Run the full quality gate — fmt, lint, tests, coverage, CRAP
+---
+
+You are in the **QA stage** (see .claude/keeler.md). Run the full fast gate and report the results honestly — never hide or hand-wave a failure.
+
+1. Run `just dev` (fmt → lint → nextest + doc tests → coverage → cargo-crap with `--threshold 15 --fail-above`).
+2. If any step fails, show the actual output, diagnose, fix, and re-run from the failed step. Coverage/CRAP failures are usually missing tests, not broken code — prefer adding tests over restructuring.
+3. Run `just cov` and inspect the summary: changed code must have no uncovered lines. If lines in this change are uncovered, write tests for them (test-first) and re-run.
+4. If `crap-baseline.json` exists, run `just crap-delta` and include the per-function delta (regressions / improvements / new) in the report. A regression fails the gate: decompose the offending function or cover it better, then re-run.
+5. Report a compact results table:
+
+| Gate                           | Result                                   |
+| ------------------------------ | ---------------------------------------- |
+| fmt                            | ✅ / ❌                                    |
+| clippy (-D warnings, pedantic) | ✅ / ❌                                    |
+| tests (nextest + doc)          | ✅ / ❌ (N passed)                         |
+| coverage                       | % lines, uncovered lines in changed code |
+| CRAP (threshold 15)            | worst function + score                   |
+| CRAP delta (if baseline)       | regressed / improved / new counts        |
+
+6. Close with the status (.claude/keeler.md § Reporting): **PASS** if every gate is green; **FAIL + gate name** otherwise; **FLAKY** if a signal was unstable.
+
+**Next stage: `/keeler:review`.** Green gates say the code does what it does; they say nothing about whether that is what the spec asked for. Only review reads the two against each other.

--- a/.claude/commands/keeler/review.md
+++ b/.claude/commands/keeler/review.md
@@ -1,0 +1,29 @@
+---
+description: Review the change — spec conformance ourselves, then the built-in code-review
+argument-hint: <spec file; empty = most recent Implemented/Approved spec>
+---
+
+Spec under review: $ARGUMENTS (if empty, use the spec whose tasks were just implemented).
+
+You are in the **review stage** (see .claude/keeler.md). The review has two parts: a spec-conformance pass that only this project can do, then the built-in code-review skill for everything generic.
+
+## Part 1 — Spec conformance (do this yourself)
+
+Check the diff (`git diff HEAD`, or the last commit if the tree is clean) against the approved spec:
+
+1. Every spec scenario has at least one test **named after it** (acceptance tests in `tests/acceptance.rs`, properties in the module).
+2. No behavior exists that no scenario demands (scope creep) — flag it as a proposed spec amendment, never silently keep it.
+3. Every invariant listed in the spec's Implementation Notes is pinned by a property test.
+4. Error messages / public API match what the scenarios promise (tokens named verbatim, etc.).
+
+## Part 2 — Generic review (delegate)
+
+Invoke the built-in `code-review` skill on the current diff. It covers correctness bugs, simplification, reuse, and efficiency with adversarial verification of findings — do not duplicate that analysis by hand. Use a higher effort level when the change is large or risky.
+
+## Report
+
+Merge both parts into one ranked findings list (spec-conformance findings first — a conformance gap outranks a style cleanup). For each finding: file:line, what's wrong, concrete failure scenario, suggested fix.
+
+**Do not apply fixes** — the user decides what to act on. Agreed fixes go back through /keeler:tdd (test first), then /keeler:qa, and return here.
+
+**Next stage: `/keeler:mutants`**, once the findings are settled.

--- a/.claude/commands/keeler/spec.md
+++ b/.claude/commands/keeler/spec.md
@@ -1,0 +1,19 @@
+---
+description: Analyze a problem and draft a Gherkin spec for approval
+argument-hint: <problem description>
+---
+
+Problem to analyze: $ARGUMENTS
+
+You are in the **spec stage** of the workflow (see .claude/keeler.md). Your job is analysis and specification only — **do not write any implementation code, do not create tasks yet**.
+
+1. **Analyze the problem.** Restate it in your own words: who has this problem, what triggers it, what the desired outcome is. List the assumptions you're making and the constraints you see (performance, error handling, edge cases).
+2. **Ask clarifying questions** if anything is ambiguous — scope, inputs, failure behavior, non-goals. Prefer asking over assuming for anything that changes the shape of the solution.
+3. **Draft the spec.** Copy `specs/TEMPLATE.md` to `specs/NN-<slug>.md` (next free number, kebab-case slug). Fill in:
+   - **Context** — the problem analysis from step 1.
+   - **Acceptance Tests** — Gherkin scenarios (Given/When/Then) covering the happy path, each edge case, and each failure mode. Scenarios must describe observable behavior, not implementation.
+   - **Implementation Notes** — approach sketch, key types, invariants worth a property test, and explicit **Non-goals**.
+   - Leave the **Tasks** section empty — that's for /keeler:tasks after approval.
+   - Set **Status: Draft**.
+4. **Present the spec** to the user: summarize it briefly and point out the decisions you made and the ones you left open.
+5. **Stop and wait for approval.** Iterate on feedback until the user approves. On approval, set **Status: Approved**. Only then may /keeler:tasks be run.

--- a/.claude/commands/keeler/tasks.md
+++ b/.claude/commands/keeler/tasks.md
@@ -1,0 +1,20 @@
+---
+description: Break an approved spec into TDD tasks with acceptance criteria
+argument-hint: <spec file, e.g. specs/01-foo.md>
+---
+
+Spec to break down: $ARGUMENTS (if empty, use the most recent spec with Status: Approved).
+
+You are in the **task breakdown stage** (see .claude/keeler.md). The spec must have **Status: Approved** — if it's still Draft, stop and tell the user to approve it first (via /keeler:spec iteration).
+
+1. **Read the spec** and its scenarios carefully.
+2. **Break the work into ordered tasks** (T1, T2, …), each one small enough to be a single red→green→refactor cycle. For every task specify:
+   - a one-line name describing the behavior it delivers,
+   - which spec scenarios it covers (every scenario must be owned by exactly one task),
+   - which test types pin it: unit, property (state the invariant), and/or acceptance,
+   - dependencies on earlier tasks, if any.
+3. **Order tasks** so each leaves the crate compiling and all existing tests green — walking skeleton first, edge cases and failure modes next.
+4. **Write the breakdown** into the spec's **Tasks** section as a checkbox list, following the template's format.
+5. **Present the plan**: the task list, the scenario→task mapping, and anything you noticed that the spec doesn't cover (propose a spec amendment — never silently extend scope).
+
+Do not start implementing — that's /keeler:tdd, one task at a time.

--- a/.claude/commands/keeler/tdd.md
+++ b/.claude/commands/keeler/tdd.md
@@ -1,0 +1,29 @@
+---
+description: Implement one task strictly test-first (red → green → refactor)
+argument-hint: <task, e.g. specs/01-foo.md T2; empty = next unchecked task>
+---
+
+Task to implement: $ARGUMENTS (if empty, take the first unchecked task from the most recent Approved spec).
+
+You are in the **TDD stage** (see .claude/keeler.md). Implement exactly one task, strictly test-first. Never write production code before a failing test exists.
+
+For the task's each behavior:
+
+1. **RED** — write the test first:
+   - unit tests in the module's `#[cfg(test)]` block,
+   - a proptest property test for every invariant the task specifies (ordering, idempotence, round-trip, bounds, saturation),
+   - acceptance tests in `tests/acceptance.rs` — one per spec scenario, named after the scenario, with Given/When/Then comments.
+   Run the test (`cargo nextest run <name>`) and **show that it fails for the right reason** before writing any implementation.
+2. **GREEN** — write the minimal implementation that makes the test pass. Resist implementing ahead of the tests.
+3. **REFACTOR** — clean up duplication and naming while keeping all tests green. Keep cyclomatic complexity low — anything approaching CRAP threshold 15 gets decomposed now, not later.
+
+After the task's cycles are done:
+
+4. Run `just dev` (fmt, lint, tests, coverage, CRAP). Fix anything red.
+5. Report: which tests were written (and the failure you observed at RED), what the implementation does, and gate results.
+
+**Do not tick the task's checkbox.** The box means the whole pipeline ran, and one stage of four has. /keeler:mutants ticks it at the end.
+
+**Next stage: `/keeler:qa` for this task** — not the next task. The pipeline is `tdd → qa → review → mutants`, and a task is finished when it comes out of the far end, not when its tests pass.
+
+If while implementing you discover the spec is wrong or incomplete — stop, propose a spec change, and wait for approval. Never silently drift from the spec.

--- a/.claude/keeler.md
+++ b/.claude/keeler.md
@@ -1,0 +1,136 @@
+<!-- keeler-version: 0.3.0 -->
+# Keeler — workflow rules
+
+The spec-first, test-driven workflow this project follows. Imported by CLAUDE.md.
+
+The stages below are Claude Code slash commands (`.claude/commands/keeler/`)
+and the skills beside them; they exist for Claude Code and no other agent.
+The gates are plain `cargo` (nextest, llvm-cov, mutants, crap) and `just`,
+so anyone — or any tool — can run those. Tests use `proptest` for property
+tests.
+
+## Workflow (THE LAW)
+
+Every feature follows this pipeline. Do not skip stages or reorder them.
+
+```
+problem ──▶ /keeler:spec ──▶ user approves spec ──▶ /keeler:tasks ──▶ /keeler:tdd (per task)
+                ▲                                            │
+                └── back-and-forth until approved            ▼
+                                                           /keeler:qa  (fmt, lint, tests, coverage, CRAP)
+                                                             │
+                                                             ▼
+                                                          /keeler:review
+                                                             │
+                                                             ▼
+                                                         /keeler:mutants ──▶ survivors? ──▶ strengthen tests,
+                                                             │            │          then /keeler:qa + /keeler:mutants again
+                                                             ▼            ◀──────────────┘
+                                                           done (all gates green)
+```
+
+1. **/keeler:spec** — analyze the problem, draft a Gherkin spec in `specs/`, iterate with the user until they approve it. **Never write implementation code at this stage.**
+2. **/keeler:tasks** — break the approved spec into ordered tasks, each mapped to its scenarios and test types.
+3. **/keeler:tdd** — implement one task at a time, strictly test-first (red → green → refactor). Unit tests + property tests (proptest) + acceptance tests per scenario.
+4. **/keeler:qa** — run the full quality gate: `just dev` (fmt, clippy, nextest, doc tests, coverage, cargo-crap).
+5. **/keeler:review** — spec-conformance check (scenario→test mapping, scope creep, invariant coverage) done in-project, then the built-in `code-review` skill for generic correctness/simplification — don't hand-roll what it already verifies.
+6. **/keeler:mutants** — mutation tests on changed files. Surviving mutants mean the tests are weak: strengthen the tests (never weaken the code to satisfy a mutant), then re-run /keeler:qa and /keeler:mutants until zero survivors.
+
+## Change classes
+
+Not every change is a feature. Pick the lightest class that honestly fits — and never downgrade a change mid-flight to dodge a failing gate:
+
+| Class       | When                                                 | Pipeline                                                                                 |
+| ----------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **Feature** | New behavior, changed behavior, new API              | Full: `/keeler:spec → approve → /keeler:tasks → /keeler:tdd → /keeler:qa → /keeler:review → /keeler:mutants`                       |
+| **Bugfix**  | Existing behavior is wrong                           | `/keeler:fix`: failing regression test first → minimal fix → `just dev` + `just mutants-diff`   |
+| **Trivial** | Docs, comments, config, renames — no behavior change | Fast path: `just lint` (plus `just test` if code was touched at all); no spec, no review |
+
+Rule of thumb: if you're debating whether it changes behavior, it's not trivial. If a "trivial" change makes any test fail, it wasn't trivial — reclassify.
+
+## Commits
+
+**Never commit without explicit user confirmation.** Finish the work, run the gates, then ask — the user decides when a commit happens and may want to review the diff first. This applies to every stage, including "obvious" checkpoints like a finished task or a green pipeline.
+
+## Reporting
+
+**Every finished task ends with a summary in English**, regardless of the conversation language. The summary must cover:
+
+- what was done (tests written, code changed, gates run — with real numbers);
+- **problems discovered along the way**: failing gates, surviving mutants, spec gaps, pipeline holes, ambiguities — and how each was resolved or why it was left open;
+- open questions that need a user decision (e.g. proposed spec amendments);
+- what the next step is;
+- a closing one-line status: **PASS** (all gates green), **FAIL** (name the gate that failed), or **FLAKY** (unstable signal — rerun before trusting it).
+
+Never bury a discovered problem in the middle of a transcript — it must reappear in the summary even if it was already mentioned when found.
+
+## Specs (THE LAW)
+
+All feature specs live in `specs/`, written Gherkin style (Given/When/Then). Copy `specs/TEMPLATE.md` for new ones; number them `NN-slug.md`.
+
+- **Never modify a spec file without explicit permission from the user.** The one exception is the `Status:` line and task checkboxes — pipeline bookkeeping: /keeler:spec sets Approved on the user's approval, /keeler:mutants ticks a task's box and sets the spec Implemented when the final gate is clean. Nothing earlier ticks anything — a box ticked after /keeler:tdd would mean "one stage of four ran", and an unreviewed task would look exactly like a finished one.
+- A spec's Acceptance Tests section IS the acceptance criteria — every scenario must map to at least one test named after it.
+- When a spec needs to change (scope change, new edge case), propose the change and wait for approval before editing the file.
+
+## Quality gates
+
+All of these must be green before a feature is considered done:
+
+| Gate       | Command                                               | Bar                                            |
+| ---------- | ----------------------------------------------------- | ---------------------------------------------- |
+| Format     | `cargo fmt --all -- --check`                          | clean                                          |
+| Lints      | `cargo clippy --all-targets -- -D warnings`           | zero warnings (pedantic is on)                 |
+| Tests      | `cargo nextest run --all-targets && cargo test --doc` | all pass                                       |
+| Coverage   | `just cov`                                            | no uncovered lines in changed code             |
+| CRAP       | `just crap`                                           | no function above threshold 15                 |
+| Mutation   | `just mutants-diff`                                   | zero surviving mutants in changed files        |
+| CRAP delta | `just crap-delta`                                     | no function's CRAP score regressed vs baseline |
+
+**The review stage leaves no artifact.** Every other gate in this table
+fails loudly when it is not met. Review does not — nothing can notice when
+it is skipped, and in the repository that ships Keeler it was skipped for
+twenty tasks before anyone did. There is no mechanism that will catch this
+for you; what there is, is a pipeline whose commands lead from each stage
+to the next, and the discipline to follow them.
+
+**Baseline discipline:** `crap-baseline.json` is **committed to the repository** — it is the shared reference every developer and CI measures against, so the ratchet works for the whole team, not just one machine. `just crap-delta` shows per-function before/after and fails on any regression: the "did this change make the codebase worse?" gate. Refresh the baseline (`just crap-baseline`) only deliberately, in its own commit — a moved baseline is a visible decision, reviewable like any other diff.
+
+## Commands
+
+```bash
+just            # list recipes
+just test       # nextest + doc tests
+just lint       # fmt --check + clippy -D warnings
+just ci         # lint + test
+just cov        # coverage summary (cargo-llvm-cov)
+just crap       # coverage + CRAP gate (cargo-crap, threshold 15)
+just crap-baseline  # record CRAP baseline before a feature
+just crap-delta     # CRAP before/after vs baseline; fails on regression
+just dev        # fmt, lint, test, crap — the full fast gate
+just mutants src/lib.rs   # mutation tests for one file
+just mutants-diff         # mutation tests on files changed vs HEAD
+just dev-full   # dev + all mutants (slow)
+```
+
+## Skills
+
+Project skills live in `.claude/skills/<name>/SKILL.md` and load automatically when their description matches the work at hand — no invocation needed:
+
+- **property-testing** — invariant catalog and proptest patterns; fires during /keeler:tdd and when a surviving mutant points at a missing law rather than a missing example.
+- **gherkin-specs** — how to write observable, testable Given/When/Then scenarios; fires during /keeler:spec and the conformance half of /keeler:review.
+
+Add new skills the same way: a folder under `.claude/skills/`, frontmatter with `name` and a `description` that says *when* to use it — the description is the trigger.
+
+**Recommended user-level skills** for a Rust project on this workflow (installed globally, not shipped with the repo — install your own equivalents if missing):
+
+- **rust-best-practices** — idiomatic Rust: borrowing vs cloning, `Result` error handling, API design; consult while writing or refactoring any Rust code.
+- **clean-code** — naming, function size, structure; the go-to during the REFACTOR step of /keeler:tdd.
+- **rust-async-patterns** — Tokio, async traits, concurrency; the moment the project grows async code.
+
+## Testing conventions
+
+- Unit tests live in `#[cfg(test)]` blocks next to the code they test.
+- Property tests use `proptest` and live in the same blocks — reach for one whenever the code has an invariant (ordering, idempotence, round-trip, saturation, bounds).
+- Acceptance tests live in `tests/acceptance.rs` — one test per spec scenario, named after the scenario, structured as Given/When/Then comments.
+- Tests are the spec's enforcement arm: when a mutant survives, the fix is a better test, not a code tweak.
+- When proptest finds a counterexample it writes a seed file under `proptest-regressions/` — **commit those files**; they are regression tests that pin the found case forever. (A crate with no `lib.rs` has no anchor for that default path — configure `FileFailurePersistence::WithSource("proptest-regressions")` so the seeds land beside the test file.)

--- a/.claude/skills/gherkin-specs/SKILL.md
+++ b/.claude/skills/gherkin-specs/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: gherkin-specs
+description: How to write good Given/When/Then scenarios for Keeler specs. Use during /keeler:spec when drafting or amending a spec, and during /keeler:review when checking spec conformance — covers scenario granularity, observable-behavior phrasing, and the traps that make specs untestable.
+---
+
+# Writing Gherkin Scenarios That Gate Real Code
+
+A Keeler spec's scenarios ARE the acceptance criteria — each becomes a test
+named after it. Write them so that a failing test points at exactly one
+broken promise.
+
+## Rules
+
+1. **Observable behavior only.** `Then the display form is "80-101"` — yes.
+   `Then the ranges vector is merged` — no: that's implementation, a
+   refactor would break the spec without breaking the user.
+2. **One behavior per scenario.** If a scenario needs "And" more than ~3
+   times, it's two scenarios. Error cases always get their own.
+3. **Name the concrete values.** `Given the input "8100-8000"` beats
+   `Given an invalid range` — concrete values become test fixtures verbatim
+   and kill boundary mutants.
+4. **Cover the three families**: happy path, each edge (boundaries, empty,
+   maximum), each failure mode (with the exact error the user sees).
+5. **Failure scenarios name the offending input** in the error — that
+   promise ("error names the token") is itself testable behavior.
+6. **One property scenario** for every law the Implementation Notes list
+   (round-trip, idempotence, shape) — phrased as `Given any valid X`.
+
+## Template
+
+```
+### Scenario: <behavior in one line, will become a test name>
+
+Given <concrete precondition, with real values>
+When  <single action>
+Then  <observable outcome>
+And   <at most a couple more observables>
+```
+
+## Smells
+
+- A scenario no test could fail → not observable, rewrite.
+- Two scenarios that can't both be implemented → the spec contradicts
+  itself; resolve before approval, not in code.
+- A scenario the implementation satisfies "by accident" with no dedicated
+  test → conformance gap; /keeler:review must flag it.

--- a/.claude/skills/property-testing/SKILL.md
+++ b/.claude/skills/property-testing/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: property-testing
+description: Catalog of property-test invariants and proptest patterns for Rust. Use when writing tests during /keeler:tdd or strengthening tests after /keeler:mutants — whenever code has an invariant worth pinning (round-trips, ordering, idempotence, bounds, merging) or a surviving mutant points at a general gap rather than a missing example.
+---
+
+# Property-Testing Patterns
+
+A property test doesn't check one example — it states a law and lets
+randomness hunt for a counterexample. When a mutant survives, ask first:
+"is there a _law_ this mutant breaks?" — one strengthened property usually
+kills a whole family of mutants that example tests would need one-by-one.
+
+## Invariant catalog
+
+Scan the code for these shapes; each maps to a ready-made property:
+
+| Shape in the code                   | Law to pin                                                            |
+| ----------------------------------- | --------------------------------------------------------------------- |
+| Parse + Display pair                | **Round-trip**: `parse(display(x)) == x`                              |
+| Normalization / canonicalization    | **Idempotence**: `f(f(x)) == f(x)`                                    |
+| Sort / merge / dedup                | **Shape**: output sorted, no overlaps/duplicates (check `windows(2)`) |
+| Aggregation (`len`, `sum`, `count`) | **Consistency**: `len() == iter().count()`; total equals sum of parts |
+| Membership + construction           | **Cross-check**: `contains(p)` ⇔ some input covers `p`                |
+| Saturating / clamping arithmetic    | **Bounds**: result within `[min, max]` for any input                  |
+| Order-insensitive operations        | **Permutation**: shuffling input doesn't change output                |
+| Two implementations (fast + naive)  | **Oracle**: `fast(x) == naive(x)` for all x                           |
+
+## Proptest mechanics
+
+```rust
+mod properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn round_trips(pairs in prop::collection::vec((1u16..=65535, 1u16..=65535), 1..10)) {
+            // build input from generated pairs, then assert the law
+        }
+    }
+}
+```
+
+- Generate the _input the user could type_, not the internal representation —
+  the parser is part of what's under test.
+- Constrain strategies to **valid** domain (e.g. `1u16..=65535`), and write a
+  _separate_ property for invalid input if rejection is a law too.
+- `prop_assert!`/`prop_assert_eq!` (not `assert!`) — they report the minimal
+  counterexample after shrinking.
+- When proptest finds a failure it writes a seed file under
+  `proptest-regressions/` — **commit it**; it pins the counterexample forever.
+- Boundary traps love `u16`/`u32` edges: always let strategies reach the
+  extremes (`=65535`, `u64::MAX`) — off-by-one mutants live there.

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ Cargo.lock
 mutants.out/
 mutants.out.old/
 lcov.info
+crap-report.json
+mutants.out*/
+
+# Claude Code: the shared workflow (commands, skills, keeler.md) is committed;
+# per-developer permissions and stray agent worktrees are not.
+.claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ All feature specs live in `specs/`. They are written in Gherkin style (Given/Whe
 
 ## Before committing
 
-1. Run `just dev` — fmt, clippy, tests, and the dogfood run (score the tool against its own source).
-2. If it passes, run `just dev-mutants-diff` — mutation tests on the `src/**/*.rs` files changed vs HEAD (it re-runs `just dev` first). Skip this step only when the diff touches nothing but `.md` and/or `.yml` files.
+1. Run `just dev` — fmt, clippy, tests, and `just crap` (score the tool against its own source).
+2. If it passes, run `just dev-mutants-diff` — mutation tests on the changed `src/` lines (it re-runs `just dev` first). Skip this step only when the diff touches nothing but `.md` and/or `.yml` files.
 
-Both must be clean before any commit. Never commit with a failing dogfood run or surviving mutants.
+Both must be clean before any commit. Never commit with a failing CRAP gate or surviving mutants.
 
 Exception: if the diff touches only `.md` files (docs, specs), no pre-commit check is needed — `just dev` / `just dev-mutants-diff` can be skipped.
 
@@ -114,3 +114,20 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
 - CLI integration tests live in `tests/cli.rs` and exercise the binary end-to-end via `assert_cmd`.
 - The integration test in `tests/integration.rs` exercises the full pipeline against `tests/fixtures/sample_project/` and is the only test that catches path-matching regressions across the complexity/coverage boundary.
 - The fixture includes a deliberate relative-path LCOV file to exercise suffix matching.
+
+## Keeler workflow
+
+This project follows the Keeler spec-first, test-driven workflow:
+
+@.claude/keeler.md
+
+Two local deviations from a stock Keeler install, both because this repo *is*
+the CRAP tool:
+
+- The `crap*` recipes run `cargo run --release --`, not the installed `cargo
+  crap` — gating on a released binary would score code that isn't the code
+  under review.
+- Keeler's `keeler.yml` workflow is not installed; `.github/workflows/ci.yml`
+  already runs every Keeler gate plus an OS matrix, MSRV, `cargo audit`, and
+  the Self-score baseline/badge/PR-comment pipeline. `just keeler-upgrade`
+  will re-drop `keeler.yml`; delete it again.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 jsonschema = { version = "0.46", default-features = false }
+proptest = "1.11.0"
 
 # cargo-binstall: download a pre-built binary instead of compiling from a source.
 # Archive naming matches the release workflow: cargo-crap-v{version}-{target}.tar.gz

--- a/Justfile
+++ b/Justfile
@@ -23,37 +23,103 @@ check:
 # Run all CI checks locally (requires cargo-nextest: cargo binstall cargo-nextest)
 ci: lint test
 
-# Dogfood: score cargo-crap against itself (requires cargo-llvm-cov)
-dogfood:
-    cargo llvm-cov --lcov --output-path lcov.info --workspace
-    cargo run --release -- --lcov lcov.info --path src --threshold 15 --fail-above
+# The CRAP recipes below run cargo-crap from *this* source tree
+# (`cargo run --release`), never the installed `cargo crap`: the tool under
+# test is the tool doing the measuring, so gating on a released binary would
+# score code that isn't the code under review. Fixtures are excluded to match
+# the Self-score job in CI — deliberately crappy sample projects are inputs,
+# not source.
+crap_bin := "cargo run --release --"
+crap_scope := "--workspace --exclude 'tests/fixtures/**'"
 
-dev: fmt lint test dogfood
+# Line coverage summary; fails mechanically below 90% lines
+cov:
+    cargo llvm-cov nextest --all-targets --summary-only --fail-under-lines 90
+
+# Dogfood: coverage + CRAP gate, fails if any function scores above threshold 15
+crap:
+    cargo llvm-cov --lcov --output-path lcov.info --workspace
+    {{crap_bin}} --lcov lcov.info {{crap_scope}} --threshold 15 --fail-above
+
+# Record a CRAP baseline (run before starting a feature)
+crap-baseline:
+    cargo llvm-cov --lcov --output-path lcov.info --workspace
+    {{crap_bin}} --lcov lcov.info {{crap_scope}} --format json --sort file --output crap-baseline.json
+    @echo "CRAP baseline saved to crap-baseline.json"
+
+# CRAP delta vs the recorded baseline: fails on threshold breach OR any regression
+crap-delta:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f crap-baseline.json ]; then
+        echo "No crap-baseline.json — run 'just crap-baseline' and commit it first." >&2
+        exit 1
+    fi
+    cargo llvm-cov --lcov --output-path lcov.info --workspace
+    {{crap_bin}} --lcov lcov.info {{crap_scope}} --threshold 15 --fail-above \
+        --baseline crap-baseline.json --fail-regression
+
+# Full local gate: format, lint, tests, coverage, CRAP
+dev: fmt lint test crap
 
 # Mutation tests for a specific file: just mutants src/delta.rs
 mutants FILE:
     cargo mutants --file {{FILE}}
 
-# Full validation including mutation tests (slow)
-dev-full: dev
+# Mutation tests on every file (slow)
+mutants-all:
     cargo mutants
 
-# Mutation tests only on files changed vs HEAD (uncommitted) or last commit.
-# The 'src/**/*.rs' pathspec catches files inside subdirectories
-# (src/report/sarif.rs, etc.) — a plain 'src/*.rs' would skip them.
-dev-mutants-diff: dev
+# Mutation tests on changed lines only
+mutants-diff:
     #!/usr/bin/env bash
     set -euo pipefail
-    # First: uncommitted changes (staged + unstaged)
-    files=$(git diff --name-only HEAD -- 'src/**/*.rs' 'src/*.rs' 2>/dev/null || true)
-    # Fallback: files changed in the last commit
-    if [ -z "$files" ]; then
-        files=$(git diff --name-only HEAD~1 HEAD -- 'src/**/*.rs' 'src/*.rs' 2>/dev/null || true)
+    # Which lines: uncommitted changes vs HEAD, else the branch base, else
+    # the last commit.
+    # Both pathspecs: 'src/**/*.rs' catches files inside subdirectories
+    # (src/report/sarif.rs, etc.) while 'src/*.rs' catches the top level.
+    paths=('src/*.rs' 'src/**/*.rs')
+    # New files aren't in `git diff HEAD` — intent-to-add makes their full
+    # content show up in the diff; reset afterwards to leave the index as-is.
+    # NUL-delimited into an array: paths with spaces stay whole.
+    untracked=()
+    while IFS= read -r -d '' f; do untracked+=("$f"); done \
+        < <(git ls-files -z --others --exclude-standard -- "${paths[@]}" 2>/dev/null || true)
+    if [ "${#untracked[@]}" -gt 0 ]; then git add -N -- "${untracked[@]}"; fi
+    diff_file=$(mktemp)
+    trap 'rm -f "$diff_file"' EXIT
+    git diff HEAD -- "${paths[@]}" > "$diff_file" || true
+    if [ "${#untracked[@]}" -gt 0 ]; then git reset -q -- "${untracked[@]}"; fi
+    if [ ! -s "$diff_file" ]; then
+        # A clean tree is not a measured tree: src changes committed earlier
+        # on this branch still need mutating, so diff against the branch base.
+        base=""
+        for ref in origin/main origin/master main master; do
+            if candidate=$(git merge-base HEAD "$ref" 2>/dev/null); then base="$candidate"; break; fi
+        done
+        if [ -n "$base" ] && [ "$base" != "$(git rev-parse HEAD)" ]; then
+            git diff "$base" HEAD -- "${paths[@]}" > "$diff_file" || true
+        fi
     fi
-    if [ -z "$files" ]; then
-        echo "No changed src/**/*.rs files — running all mutants"
-        cargo mutants
-    else
-        echo "Running mutants on: $files"
-        cargo mutants $(echo "$files" | sed 's/^/--file /' | tr '\n' ' ')
+    if [ ! -s "$diff_file" ]; then
+        git diff HEAD~1 HEAD -- "${paths[@]}" > "$diff_file" 2>/dev/null || true
     fi
+    if [ ! -s "$diff_file" ]; then
+        # An honest gate says what it did not measure — it never reports the
+        # absence of survivors as evidence about a change it cannot see.
+        # For everything mutants can measure, use `just mutants-all`.
+        echo "No src/ changes — outside the mutation gate's reach; nothing was measured"
+        exit 0
+    fi
+    echo "Running mutants on changed lines (--in-diff)"
+    cargo mutants --in-diff "$diff_file"
+
+# The pre-commit gate: the full fast gate, then mutants on what changed
+dev-mutants-diff: dev mutants-diff
+
+# Full validation including mutation tests (slow)
+dev-full: dev mutants-all
+
+# Upgrade Keeler itself (KEELER_REF=v0.1.0 just keeler-upgrade to pin a tag)
+keeler-upgrade:
+    curl -fsSL https://raw.githubusercontent.com/minikin/keeler/main/install.sh | bash -s .

--- a/KEELER.md
+++ b/KEELER.md
@@ -1,0 +1,175 @@
+# Keeler — a Polygraph for AI-Written Code
+
+**Keeler** is a way of building software *with* AI that stays trustworthy:
+the human owns decisions, the agent does the labor, and machines — not
+vibes — verify the result.
+
+It is built for **[Claude Code](https://claude.com/claude-code)** and
+**Rust**, and both are load-bearing rather than incidental. The pipeline
+below is a set of Claude Code slash commands and skills; another agent
+will not find them. Every gate is a Rust tool — `cargo nextest`,
+`cargo llvm-cov`, `cargo mutants`, `cargo crap`, `proptest`.
+
+The method carries over to any agent and any language with an equivalent
+toolchain. This implementation does not, and saying otherwise would be the
+kind of comfortable overclaim the gates below exist to catch.
+
+It is named after **[Leonarde Keeler](https://en.wikipedia.org/wiki/Leonarde_Keeler)**, who built the first practical
+polygraph (it's in the Smithsonian). A polygraph doesn't detect lies — it
+records several independent physiological channels at once, on the theory
+that you can fool one channel but not all of them. Keeler applies the same
+theory to AI-generated code: plausible-looking output can fool a human
+reader, but it cannot simultaneously fool the test suite, the coverage
+profiler, the complexity score, an independent review, and mutation testing.
+
+> **Verdicts.** Every task's final report ends with a one-line status:
+> **PASS** (all gates green), **FAIL** (a gate failed — the report names
+> which one), or **FLAKY** (unstable signal — rerun before trusting it).
+
+## The one-paragraph version
+
+Every feature starts as a **conversation, not code**: the AI analyzes the
+problem and writes a short spec with concrete Given/When/Then scenarios. The
+human reads it, pushes back, and **approves it** — that's the only moment
+requirements get decided. From there the AI works test-first through small
+tasks, and the result has to survive a gauntlet of mechanical gates: linting,
+tests, coverage, a complexity-vs-coverage score (CRAP), an independent code
+review, and finally **mutation testing** — a tool that deliberately breaks the
+code to check whether the tests notice. If a mutant survives, the tests were
+too weak; the fix is always a stronger test, never a code tweak to appease the
+tool.
+
+## Three roads: not every change is a feature
+
+A pipeline nobody follows for small changes is a pipeline that gets bypassed
+for big ones too. So the first question is always: *what kind of change is
+this?*
+
+```mermaid
+flowchart TD
+    A[Incoming change] --> B{Does it change<br/>behavior?}
+    B -- "No — docs, comments,<br/>config, renames" --> C[<b>Trivial: fast path</b><br/>just lint<br/>+ just test if code touched]
+    B -- "Yes — existing behavior<br/>is wrong" --> D[<b>Bugfix: /keeler:fix</b><br/>failing regression test first,<br/>then the minimal fix]
+    B -- "Yes — new or changed<br/>behavior, new API" --> E[<b>Feature: /keeler:feature</b><br/>full pipeline below]
+    C --> F[English summary,<br/>commit on confirmation]
+    D --> G[just dev + mutants on<br/>the changed lines] --> F
+    E --> F
+```
+
+Two honesty rules keep the classes meaningful:
+
+- **Never downgrade mid-flight.** A change doesn't become "trivial" because a
+  gate went red. If a trivial change breaks any test, it wasn't trivial —
+  reclassify and take the proper road.
+- **Bugs are reproduced before they are fixed.** `/keeler:fix` refuses to touch code
+  until a regression test fails on the current build for the right reason. If
+  the bug lives in behavior no spec covers, the spec gets a one-scenario
+  amendment (human-approved) first — otherwise the fix would quietly encode a
+  requirement nobody decided.
+
+## The feature pipeline
+
+```mermaid
+flowchart TD
+    P[Problem] --> S["/keeler:spec — analysis +<br/>Gherkin scenarios"]
+    S <--> H{{Human reviews,<br/>pushes back}}
+    H -- approve --> T["/keeler:tasks — small steps,<br/>each mapped to scenarios"]
+    T --> TDD["/keeler:tdd — per task:<br/>RED failing test → GREEN<br/>minimal code → REFACTOR"]
+    TDD --> QA["/keeler:qa — fmt, clippy, tests,<br/>coverage ≥ 90%, CRAP ≤ 15"]
+    QA --> R["/keeler:review — spec conformance<br/>+ independent code review"]
+    R --> M["/keeler:mutants — inject bugs,<br/>tests must catch them"]
+    M -- "survivors" --> ST[Strengthen tests,<br/>never weaken code] --> QA
+    M -- "zero survivors" --> DONE[Spec → Implemented<br/>CRAP delta vs baseline<br/>English summary<br/>commit on confirmation]
+```
+
+The loop at the bottom right is the heart of it: a surviving mutant sends the
+work back through QA with *stronger tests*, and the cycle repeats until the
+suite catches every injected bug.
+
+## Why each stage exists
+
+| Stage                     | What it does                                                               | The AI failure mode it defends against                                               |
+| ------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **/keeler:spec** + approval      | Problem analysis → Gherkin scenarios → human sign-off                      | AI confidently building the wrong thing; requirements drifting mid-implementation    |
+| **/keeler:tasks**                | Spec broken into small ordered steps, each mapped to scenarios             | "Big bang" generation that's impossible to review; scenarios silently dropped        |
+| **/keeler:tdd**                  | Red → green → refactor; the failing test is shown *before* the code exists | AI writing tests after the fact that merely describe what the code already does      |
+| **/keeler:qa** (coverage + CRAP) | Every line of new code exercised; no function both complex and untested    | Plausible-looking generated code that nothing actually executes                      |
+| **/keeler:review**               | Spec-conformance check + independent generic review                        | Scope creep; code that satisfies the letter of tests but not the spec                |
+| **/keeler:mutants**              | Injects bugs; every one must be caught by a test                           | Assertion-free or tautological tests — the classic weakness of generated test suites |
+| **CRAP delta**            | Compares scores before/after the feature                                   | Slow erosion: each change "fine", the codebase quietly getting worse                 |
+| **/keeler:fix** (bugfix road)    | Failing regression test before any fix; minimal change after               | "Fixing" what was never reproduced; drive-by rewrites hiding inside a bugfix         |
+
+The through-line: **at no point does "the AI said so" count as evidence.**
+Specs are approved by a human; everything else is verified by a machine.
+
+## The polygraph, literally
+
+The metaphor is not decoration — every part of the workflow has an exact
+counterpart in real polygraph practice:
+
+| Keeler | Polygraph practice |
+|---|---|
+| Spec written, then **approved before any code** | Question review: the examinee sees and agrees the questions *before* the session — surprises invalidate the test |
+| fmt / clippy | Instrument calibration |
+| Unit & acceptance tests | Relevant questions |
+| Coverage ("did anything exercise this line?") | A channel with no sensor attached records nothing — uncovered code is an unmonitored channel |
+| CRAP score | Stress indicator: complex *and* untested is where deception hides |
+| **Mutation testing** | **Control questions**: a known lie is planted and the sensors *must* react — if they don't, the instrument itself is broken and nothing it said can be trusted |
+| `crap-baseline` / `crap-delta` | Baseline: examiners measure *deviation from baseline*, never absolutes |
+| Final report with a PASS / FAIL / FLAKY status | The examiner's report |
+
+The control-question row is the deepest part of the mapping: mutation
+testing doesn't test the code, it tests the *tests* — exactly as control
+questions don't probe the examinee, they probe the instrument.
+
+## The moving parts
+
+- `specs/` — one Markdown file per feature: context, Given/When/Then
+  scenarios (these ARE the acceptance criteria), task checklist,
+  implementation notes. Specs are law: the AI may not edit one without
+  permission (only `Status:` and task checkboxes move as bookkeeping).
+- `.claude/commands/` — one slash command per stage (`/keeler:spec`, `/keeler:tasks`,
+  `/keeler:tdd`, `/keeler:qa`, `/keeler:review`, `/keeler:mutants`), plus `/keeler:feature` which runs the whole
+  pipeline with a hard stop at spec approval, and `/keeler:fix` for the bugfix road.
+- `.claude/keeler.md` — the standing rules the AI works under (imported by
+  `CLAUDE.md`): the pipeline, change classes, quality bars, "never commit without confirmation", "every task
+  ends with an English summary that re-surfaces discovered problems".
+- `.claude/skills/` — knowledge that loads itself when relevant:
+  **property-testing** (invariant catalog for the TDD and mutation stages)
+  and **gherkin-specs** (scenario-writing rules for the spec stage). Global
+  companions worth installing: rust-best-practices, clean-code,
+  rust-async-patterns.
+- `Justfile` — every gate as one short command (`just dev`, `just
+  mutants-diff`, `just crap-delta`), so the human can re-run anything the AI
+  claims.
+- `.github/workflows/ci.yml` — the same gates in CI (installed as
+  `keeler.yml` in your project): lints, tests,
+  coverage ≥ 90%, CRAP ≤ 15, and mutation tests on the changed lines of every
+  PR. Locally the law is discipline; in CI it's physics.
+
+## Tests, three ways
+
+1. **Unit tests** pin individual behaviors, next to the code.
+2. **Property tests** (proptest) pin *invariants* — "display then parse always
+   returns the same set", "output is always sorted and non-overlapping" —
+   letting randomness hunt for the edge cases nobody thought to write down.
+   When proptest finds a counterexample, its seed file under
+   `proptest-regressions/` is committed: the found case is pinned forever.
+3. **Acceptance tests** — one per spec scenario, named after it, so
+   `grep` answers "is this scenario actually enforced?"
+
+## What this looked like in practice
+
+In the first real run of this pipeline (a port-range parser: `"80,443,8000-8100,22"` → canonical port set), the gates caught, mechanically, everything a tired reviewer
+would miss:
+
+- The CRAP gate flagged user-facing **error messages with 0% test coverage**.
+- Mutation testing found `is_empty` was **unreachable through the public
+  API** — dead branch, now pinned by a test.
+- Mutation testing exposed a **redundant branch** in the merge logic
+  (an equivalent mutant) — the code got *simpler* as a result.
+- The pipeline itself had a hole: new untracked files escaped
+  `mutants-diff`. Found, fixed.
+
+None of those were noticed by reading the code. All of them were caught by
+gates.

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -1,0 +1,52 @@
+# Spec NN — <Title>
+
+**Status:** Draft | Approved | Implemented
+**Effort:** Small | Medium | Large
+**Module:** `src/<module>.rs`
+
+## Context
+
+<Why this feature exists: the problem, who hits it, and what changes
+for them once it ships. Capture constraints and rejected alternatives.>
+
+---
+
+## Acceptance Tests
+
+### Scenario: <behavior in one line>
+
+```
+Given <precondition>
+When  <action>
+Then  <observable outcome>
+And   <additional outcome>
+```
+
+### Scenario: <edge case>
+
+```
+Given <precondition>
+When  <action>
+Then  <observable outcome>
+```
+
+---
+
+## Tasks
+
+Each task lists its scenarios and the test types that pin it
+(unit / property / acceptance).
+
+- [ ] **T1 — <task name>** — scenarios: <list>; tests: unit + property
+- [ ] **T2 — <task name>** — scenarios: <list>; tests: acceptance
+
+---
+
+## Implementation Notes
+
+<Sketch of the approach: data flow, key types, invariants worth a
+property test, error handling. Non-goals go here too.>
+
+### Non-goals
+
+- <explicitly out of scope>


### PR DESCRIPTION
Installs [Keeler](https://github.com/minikin/keeler) — the spec-first, test-driven workflow — and reconciles it with what this repo already has.

## What lands

- `.claude/commands/keeler/` — one slash command per stage (`spec`, `tasks`, `tdd`, `qa`, `review`, `mutants`), plus `feature` and `fix`.
- `.claude/skills/` — `gherkin-specs` and `property-testing`, which load themselves when relevant.
- `.claude/keeler.md` — the standing rules, imported by `CLAUDE.md`.
- `specs/TEMPLATE.md`, `KEELER.md`.
- `proptest` as a dev-dependency (currently unused — first property test will consume it).

## The `.keeler` copies

The installer writes a `.keeler` copy beside every config it would otherwise overwrite. Three were no-ops and ours stand:

| File | Difference |
| --- | --- |
| `rustfmt.toml` | Ours is a strict superset — Keeler's had only `edition` and `max_width`. |
| `clippy.toml` | A trailing newline. |
| `.cargo-mutants.toml` | Comment wording; every setting identical. |

## The Justfile merge

Keeler's recipe set lands: `cov`, `crap`, `crap-baseline`, `crap-delta`, `mutants-all`, `mutants-diff`. `dev` becomes `fmt lint test crap`; `dev-mutants-diff` stays, now `dev` + `mutants-diff`.

`mutants-diff` is a genuine upgrade over the old whole-file gate — it mutates changed **lines** via `--in-diff`, picks up untracked files through intent-to-add, falls back to the branch base when the tree is clean, and says out loud when it measured nothing instead of reporting "no survivors" about a change it could not see.

Two deviations, both because this repo *is* the tool doing the measuring:

- **The `crap*` recipes run `cargo run --release --`, not the installed `cargo crap`.** Gating on a released binary would score code that isn't the code under review. They also exclude `tests/fixtures/**`, matching the Self-score job — the deliberately crappy sample projects are inputs, not source.
- **`keeler.yml` is not installed.** `ci.yml` already runs every gate it does, plus the OS matrix, MSRV, `cargo audit`, and the merge-base-pinned baseline/badge/PR-comment pipeline. Its `quality` job would also have pulled `cargo-crap` from crates.io. `just keeler-upgrade` will re-drop the file; delete it again. Noted in `CLAUDE.md`.

Dropped from Keeler's Justfile as inert here: the has-Rust-targets guard, the doctest auto-detection, and a `shellcheck` branch keyed on a marker file only Keeler's own repository has.

## Gates

- `just dev` — green. 194 functions analyzed, none above CRAP 15.
- `just cov` — green, and new: **97.79% lines** against Keeler's floor of 90.
- `just mutants-diff` — exit 0, nothing to measure (no `src/` changes in this PR).
- `just crap-delta` — exits 1 with a clear message; see below.

## Left open deliberately

- **No `crap-baseline.json`.** Keeler's doctrine commits one as the shared ratchet, but this repo already gates regressions in CI via the merge-base-pinned artifact (spec 22) — a committed baseline would be a second, competing source of truth. `crap-delta` therefore fails fast with `run 'just crap-baseline' and commit it first` rather than a confusing parse error. Easy to turn on later.
- **`.claude/settings.local.json` and `.claude/worktrees/` are gitignored** — the shared workflow is committed, per-developer permissions and stray agent worktrees are not.
