### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,3 +524,19 @@ output points at v2.
 ### Added
 
 - Initial release
+
+<!-- Version links -->
+
+[0.5.0]: https://github.com/minikin/cargo-crap/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/minikin/cargo-crap/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/minikin/cargo-crap/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/minikin/cargo-crap/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/minikin/cargo-crap/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/minikin/cargo-crap/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/minikin/cargo-crap/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/minikin/cargo-crap/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/minikin/cargo-crap/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/minikin/cargo-crap/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/minikin/cargo-crap/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/minikin/cargo-crap/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/minikin/cargo-crap/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,90 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0] - 2026-09-05
+
+Two new analyses land in this release: per-function uncovered line ranges
+(spec 28) and structural duplicate detection (spec 29). Both are additive
+and off by default. Library consumers who build `RenderOptions` or
+`CrapEntry` with an exhaustive struct literal need a one-line change; see
+Changed.
+
+### Added
+
+- **Structural duplicate detection** (spec 29). `--duplicates` runs a
+  second pass over the AST `cargo-crap` already walks: every function is
+  normalized into a structural tree, each subtree is fingerprinted, and
+  pairs are compared by Jaccard similarity over their fingerprint sets.
+  Pairs at or above `--dup-threshold` (default `0.82`) are reported as
+  candidates — the tool names them and stops there, because two functions
+  with the same shape may be a copy-paste bug or two unrelated trait
+  impls, and only a human can tell. Normalization erases identifiers,
+  literal values, field and path names, so renaming and retyping do not
+  change a score; operators, loop kinds, nesting and statement order are
+  structural and do. Off by default because the comparison is quadratic;
+  it needs no `--lcov`. `#[test]` functions and `#[cfg(test)]` modules are
+  excluded through the complexity pass's own filter, so the two analyses
+  cannot drift apart about what counts as source, and functions below
+  `duplicates.min-nodes` (default 20 normalized nodes) are dropped before
+  comparison — every pair of trivial accessors is a genuine structural
+  match, and reporting them buries the pairs worth reading. Configurable
+  as `duplicates.{enabled,threshold,min-nodes}` in `.cargo-crap.toml`.
+  Human output grows a `Duplicate candidates` section after the table and
+  both JSON envelopes grow a `duplicates` array; `markdown`, `pr-comment`,
+  `sarif`, `shields` and `github` warn that `--duplicates` has no effect
+  and skip the sweep rather than pay for a result they discard. The flag
+  is deliberately named apart from `--threshold`, which has meant the CRAP
+  score since v0.1.
+- **Uncovered-span hints** (spec 28). Every entry now carries the maximal
+  runs of instrumented-but-never-hit lines inside its span, so a crappy
+  function points at the lines to test rather than only at itself. JSON
+  always carries the full ranges in an additive `uncovered` array (omitted
+  when empty, or when the file had no coverage data at all). The human,
+  markdown and pr-comment tables show them in an optional `Uncovered`
+  column — `142–158, 171, 180–184 +2 more` — enabled by the
+  `uncovered-hints` key in `.cargo-crap.toml`. That key is config-only:
+  there is deliberately no CLI flag.
+
+### Changed
+
+- **BREAKING (library API):** `RenderOptions` gained `uncovered_hints:
+  bool` and `duplicates: Option<&[DuplicatePair]>`, and `CrapEntry` gained
+  `uncovered: Vec<LineRange>`. `render` / `render_delta` signatures are
+  unchanged. Code that builds either type with an exhaustive struct
+  literal must add the fields or spread `..Default::default()`; code that
+  only reads them is unaffected.
+- `Config` gained `uncovered_hints` and a `duplicates` table
+  (`DuplicatesConfig`). Both are optional, and `#[serde(deny_unknown_fields)]`
+  still rejects typos.
+- The published JSON schemas gained `duplicates` and `uncovered`
+  (`report-v1.json`, `delta-v2.json`). Both are optional additive fields,
+  so existing documents stay valid and neither envelope version was
+  bumped — but validators pinned to a *cached pre-0.5.0 copy* will reject
+  new documents, since the schemas declare `additionalProperties: false`.
+  Refresh them from the repo; the published URLs are unchanged.
+
+### Fixed
+
+- **The published schemas rejected `--duplicates` JSON.** Both envelopes
+  emitted a top-level `duplicates` array that neither schema declared,
+  and both schemas set `additionalProperties: false` — so the documented
+  validation step failed on the tool's own output. The schemas now
+  declare the array, and the CLI test suite validates a `--duplicates`
+  run of both envelopes against them.
+- **A real delta is never displayed as `±0.0`.** A `Regressed` /
+  `Improved` entry has beaten the epsilon by definition, but the
+  one-decimal Δ format rounded sub-0.05 changes to `-0.0`, which read as
+  "no change" beside a status that said otherwise. The formatter now
+  widens precision (up to three decimals) until the value is visible.
+
+### Internal
+
+- CI pins the self-score baseline to the pull request's merge base (spec
+  22) instead of the newest successful `main` run, and notes in the PR
+  comment when it had to fall back past a failed or unfinished run.
+- The repository adopted the Keeler spec-first workflow (0.4.0, graph
+  mode). Development-only: none of it ships in the crate.
+
 ## [0.4.3] - 2026-08-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ cargo fmt --all
 # Lint (warnings are errors in CI: RUSTFLAGS="-D warnings")
 cargo clippy --all-targets -- -D warnings
 
-# Run the tool against this repo (dogfood)
-cargo llvm-cov --lcov --output-path lcov.info --workspace
-cargo run --release -- --lcov lcov.info --workspace --threshold 15 --fail-above
+# Run the tool against this repo (dogfood) — prefer the recipe, which is
+# the single definition of this gate; spelling it out here lets the two drift.
+just crap
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ cargo run --release -- --lcov lcov.info --workspace --threshold 15 --fail-above
 
 ## Architecture
 
-The tool has six orthogonal modules that feed into a pipeline:
+The tool has seven orthogonal modules that feed into a pipeline:
 
 ```
 syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
@@ -78,7 +78,18 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
                   ├── github.rs           ::warning annotations
                   ├── markdown.rs         exhaustive GFM
                   ├── pr_comment.rs       opinionated PR comment
-                  └── summary.rs          --summary aggregate
+                  ├── sarif.rs            SARIF 2.1.0
+                  ├── shields.rs          Shields.io endpoint badge
+                  ├── duplicates.rs       Duplicate candidates section
+                  ├── summary.rs          --summary aggregate
+                  └── test_support.rs     shared fixtures (cfg(test))
+
+syn (Rust AST)  ──▶  src/duplicates/       second pass, only on --duplicates
+                     ├── extract.rs        one FunctionPrint per non-test fn
+                     ├── normalize.rs      AST ──▶ NormNode (names/literals erased)
+                     ├── fingerprint.rs    NormNode ──▶ BTreeSet<Fingerprint>
+                     ├── compare.rs        pairwise Jaccard ──▶ Vec<DuplicatePair>
+                     └── scan.rs           walk a tree, drive the four above
 ```
 
 **`src/score.rs`** — Pure formula: `CRAP(m) = comp(m)² × (1 − cov(m)/100)³ + comp(m)`. No I/O, no dependencies on other modules.
@@ -96,7 +107,9 @@ syn (Rust AST)                          LCOV file (cargo llvm-cov / tarpaulin)
 
 **`src/config.rs`** — Optional `.cargo-crap.toml` loader. Walks up from CWD until the file is found; returns `Config::default()` if absent. Uses `#[serde(deny_unknown_fields)]` to catch typos. CLI flags always override config values.
 
-**`src/report/`** — Renders `Vec<CrapEntry>` or `DeltaReport` in five formats: human (colored Unicode table), JSON (versioned envelope), GitHub Actions (`::warning` annotations), Markdown (exhaustive GFM table), and pr-comment (opinionated PR-comment with capped sections + `<details>` blocks). The entry file `src/report.rs` is a thin dispatcher (`Format` enum, `render` / `render_delta` / `render_summary` / `render_delta_summary`); each format lives in a sibling submodule. Cross-cutting helpers (`Grade`, `coverage_bar`, `delta_display`) live in `report/types.rs`; optional GitHub source-link wrapping (`SourceLinks`, `linkify`) lives in `report/links.rs`; per-crate rollup tables (workspace mode) live in `report/per_crate.rs`. Each submodule owns its `#[cfg(test)] mod tests` block; shared fixtures (e.g. `sample()`) live in `report/test_support.rs`.
+**`src/report/`** — Renders `Vec<CrapEntry>` or `DeltaReport` in seven formats: human (colored Unicode table), JSON (versioned envelope), GitHub Actions (`::warning` annotations), Markdown (exhaustive GFM table), pr-comment (opinionated PR-comment with capped sections + `<details>` blocks), SARIF 2.1.0, and Shields.io endpoint-badge JSON. The entry file `src/report.rs` is a thin dispatcher (`Format` enum, `render` / `render_delta` / `render_summary` / `render_delta_summary`); each format lives in a sibling submodule. Cross-cutting helpers (`Grade`, `coverage_bar`, `delta_display`) live in `report/types.rs`; optional GitHub source-link wrapping (`SourceLinks`, `linkify`) lives in `report/links.rs`; per-crate rollup tables (workspace mode) live in `report/per_crate.rs`. Each submodule owns its `#[cfg(test)] mod tests` block; shared fixtures (e.g. `sample()`) live in `report/test_support.rs`.
+
+**`src/duplicates/`** — A second, opt-in pass over the same AST (`--duplicates`). `extract` collects one `FunctionPrint` per non-test function, `normalize` erases identifiers, literal values and field/path names while keeping control flow, operators, receiver shape and statement order, `fingerprint` hashes every normalized subtree into a `BTreeSet<Fingerprint>` (FNV-1a, not `DefaultHasher` — the fingerprints must be stable across processes), and `compare` scores every pair by Jaccard similarity. Quadratic in the number of functions, which is why it is off by default; functions below `duplicates.min-nodes` (default 20) are dropped before comparison. It reuses the complexity pass's test filter, so the two analyses cannot disagree about what counts as source.
 
 **`src/main.rs`** — CLI via `clap`. Handles the `cargo crap` subcommand invocation by stripping the leading `crap` argument when detected. Heavy logic is extracted into `validate_args`, `collect_complexity`, `apply_filters`, `load_coverage`, and `do_render` to keep `main` CC below 15.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development setup
 
-1. Install Rust (stable, 1.85+): https://rustup.rs
+1. Install Rust (stable, 1.88+ — the crate's MSRV): https://rustup.rs
 2. Clone the repository and build:
    ```bash
    cargo build --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-crap"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Oleksandr Prokhorenko <warbles.lieu_04@icloud.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ jsonschema = { version = "0.46", default-features = false }
 proptest = "1.11.0"
 
 # cargo-binstall: download a pre-built binary instead of compiling from a source.
-# Archive naming matches the release workflow: cargo-crap-v{version}-{target}.tar.gz
+# Archive naming matches the release workflow: cargo-crap-{target}.tar.gz
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/cargo-crap-{ target }.tar.gz"
 bin-dir = "cargo-crap{ binary-ext }"

--- a/Justfile
+++ b/Justfile
@@ -35,7 +35,9 @@ ci: lint test
 # test is the tool doing the measuring, so gating on a released binary would
 # score code that isn't the code under review. Fixtures are excluded to match
 # the Self-score job in CI — deliberately crappy sample projects are inputs,
-# not source.
+# not source. Since spec 14 that exclusion is redundant (`tests/**` is a
+# default exclude); it is kept explicit so the intent survives a change to
+# the default list.
 crap_bin := "cargo run --release --"
 crap_scope := "--workspace --exclude 'tests/fixtures/**'"
 
@@ -66,7 +68,9 @@ crap-delta:
     {{crap_bin}} --lcov lcov.info {{crap_scope}} --threshold 15 --fail-above \
         --baseline crap-baseline.json --fail-regression
 
-# Full local gate: format, lint, tests, coverage, CRAP
+# Full local gate: format, lint, tests, CRAP. Note `cov` is NOT part of it —
+# the `crap` recipe runs llvm-cov to produce lcov.info but never applies the
+# 90% line bar; run `just cov` for that.
 dev: fmt lint test crap
 
 # Mutation tests for a specific file: just mutants src/delta.rs

--- a/KEELER.md
+++ b/KEELER.md
@@ -1,5 +1,13 @@
 # Keeler — a Polygraph for AI-Written Code
 
+> **Which file is this?** `KEELER.md` is the methodology as published
+> upstream — the essay, kept here so the repository explains itself.
+> `.claude/keeler.md` is this project's operative copy, imported by
+> `CLAUDE.md` and read by the agent; local deviations are recorded in
+> `CLAUDE.md` under "Keeler workflow". Edit `.claude/keeler.md` to change
+> how this repository works; `KEELER.md` is refreshed from upstream by
+> `just keeler-upgrade`.
+
 **Keeler** is a way to build software *with* AI that remains trustworthy: humans own the decisions, the agent does the work, and machines — not vibes — verify the result.
 
 It is built for **[Claude Code](https://claude.com/claude-code)** and

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Windows: download `cargo-crap-x86_64-pc-windows-msvc.zip` from the [latest relea
 ## Quick start
 
 ```bash
+# 0. cargo-llvm-cov is a separate tool; install it once.
+cargo install cargo-llvm-cov
+
 # 1. Generate an LCOV coverage report.
 cargo llvm-cov --lcov --output-path lcov.info
 
@@ -100,11 +103,13 @@ Example output:
 
 ```
 ┌───┬───────┬────┬───────────────────┬──────────┬───────────────┐
-│   │  CRAP │ CC │ Coverage          │ Function │ Location      │
+│   ┆  CRAP ┆ CC ┆ Coverage          ┆ Function ┆ Location      │
 ╞═══╪═══════╪════╪═══════════════════╪══════════╪═══════════════╡
-│ ✗ │ 156.0 │ 12 │ ░░░░░░░░░░   0.0% │ crappy   │ src/lib.rs:24 │
-│ ▲ │   6.7 │  4 │ ████░░░░░░  44.4% │ moderate │ src/lib.rs:12 │
-│ ✓ │   1.0 │  1 │ ██████████ 100.0% │ trivial  │ src/lib.rs:8  │
+│ ✗ ┆ 156.0 ┆ 12 ┆ ░░░░░░░░░░   0.0% ┆ crappy   ┆ src/lib.rs:24 │
+├╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ ▲ ┆   6.7 ┆  4 ┆ ████░░░░░░  44.4% ┆ moderate ┆ src/lib.rs:12 │
+├╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ ✓ ┆   1.0 ┆  1 ┆ ██████████ 100.0% ┆ trivial  ┆ src/lib.rs:8  │
 └───┴───────┴────┴───────────────────┴──────────┴───────────────┘
 ✗ 1/3 function(s) exceed CRAP threshold 30.
 ```
@@ -113,7 +118,7 @@ Example output:
 
 | Flag                                                             | Default       | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--lcov <FILE>`                                                  | —             | LCOV file from `cargo llvm-cov` or `cargo tarpaulin`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `--lcov <FILE>`                                                  | —             | LCOV file from `cargo llvm-cov` or `cargo tarpaulin`. **Omitting it is not a coverage-free run**: every function is scored as if it had 0% coverage, so CRAP collapses to `CC² + CC` and the whole table reads red. That is useful for a first look at the complexity distribution — it is not a CRAP run.                                                                                                                                                                            |
 | `--path <DIR>`                                                   | `.`           | Root to walk for `.rs` files (respects `.gitignore`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `--threshold <N>`                                                | `30`          | Score above which a function is flagged.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `--min <SCORE>`                                                  | —             | Hide entries below this score.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
@@ -343,6 +348,9 @@ allow   = ["generated::*", "src/generated/**"]
 epsilon = 0.01            # regression-detector tolerance
 jobs    = 4               # cap parallel analysis at 4 threads
 sort    = "file"          # entry ordering: crap (default) | file
+min     = 5.0             # hide entries scoring below this
+top     = 20              # keep only the N worst offenders
+fail-regression = true    # exit 1 when a score rises against --baseline
 show_unchanged = false    # list Unchanged rows in --baseline mode
 # Append an Uncovered column (per-function uncovered line ranges, e.g.
 # `142–158, 171, 180–184 +2 more`) to the human, markdown, and pr-comment
@@ -358,9 +366,37 @@ min-nodes = 20      # skip functions smaller than this; 0 compares everything
 
 All keys are optional. Unknown keys are rejected to catch typos.
 
+Every key above accepts both the kebab-case house spelling and its
+snake_case alias (`show-unchanged` / `show_unchanged`). Where a key and
+its flag are not spelled the same, the mapping is:
+
+| Flag                  | Config key             |
+| --------------------- | ---------------------- |
+| `--threshold`         | `threshold`            |
+| `--fail-above`        | `fail-above`           |
+| `--missing`           | `missing`              |
+| `--exclude`           | `exclude` (appends)    |
+| `--allow`             | `allow`                |
+| `--min`               | `min`                  |
+| `--top`               | `top`                  |
+| `--sort`              | `sort`                 |
+| `--epsilon`           | `epsilon`              |
+| `--jobs`              | `jobs`                 |
+| `--fail-regression`   | `fail-regression`      |
+| `--show-unchanged`    | `show-unchanged`       |
+| `--duplicates`        | `duplicates.enabled`   |
+| `--dup-threshold`     | `duplicates.threshold` |
+| *(no flag)*           | `duplicates.min-nodes` |
+| *(no flag)*           | `uncovered-hints`      |
+| *(no key)*            | `--path`, `--format`, `--output`, `--summary`, `--workspace`, `-p`/`--package`, `--baseline`, `--no-default-excludes`, `--repo-url`, `--commit-ref` |
+
+`default-excludes` is the one key with no direct flag equivalent: it
+*replaces* the built-in default list, where `--no-default-excludes`
+empties it.
+
 ## Design
 
-The tool has six orthogonal modules. Each is testable in isolation; the
+The tool has seven orthogonal modules. Each is testable in isolation; the
 join between them has its own integration test.
 
 ```
@@ -384,8 +420,16 @@ join between them has its own integration test.
              └─────┬────┘     └───────┘
                    ▼
              ┌──────────┐
-             │  report  │  ← human / JSON / GitHub / Markdown
-             └──────────┘
+             │  report  │  ← human / JSON / GitHub / Markdown /
+             └──────────┘     pr-comment / SARIF / Shields
+
+                syn
+            (Rust AST)
+                 │
+                 ▼
+          ┌────────────┐
+          │ duplicates │  ← second pass, only on --duplicates
+          └────────────┘
 ```
 
 ### The path-matching problem
@@ -419,6 +463,34 @@ would otherwise silently bind them to whatever file happened to exist
 under the tool's working directory. The regression test
 `relative_coverage_paths_are_not_resolved_against_cwd` in `src/merge.rs`
 pins this.
+
+### What gets a score, and what counts as complexity
+
+Two things surprise people the first time their numbers do not match
+another tool.
+
+**Test code is never scored.** A function carrying `#[test]` and every
+item inside a `#[cfg(test)] mod` is skipped by the complexity pass, so it
+never reaches the table. (Only that exact spelling — `#[cfg(not(test))]`
+and `#[cfg(any(test, …))]` are left alone.) On top of that, `tests/**`,
+`benches/**` and `examples/**` are excluded at walk time; pass
+`--no-default-excludes` to get them back. So "my test helpers are
+missing" is the tool working as intended, not a path-matching failure.
+
+**Cyclomatic complexity starts at 1 and adds one for each of:** `if`
+(including every `else if`), `for`, `while`, `loop`, **every** `match`
+arm, each `&&` and `||`, and each `?`. Two consequences worth knowing:
+
+- A three-arm `match` adds 3, giving CC 4 — textbook McCabe counts N−1
+  branch points and would say 3. Scores are internally consistent and
+  comparable across runs of this tool; they are not comparable to
+  another tool's numbers.
+- `?` counts as a decision point, so an idiomatic `Result` chain scores
+  higher than its branching suggests.
+
+Closures and items nested inside a function body (a local `fn`, `impl`,
+`mod`, …) are *not* folded into the enclosing function — each is its own
+scope, and a closure's branches belong to the closure.
 
 ### The `--missing` policy
 
@@ -540,6 +612,13 @@ it back so the README embed stays current:
     git push
 ```
 
+This repository does it differently, and the badge at the top of this file
+points at that: `ci.yml` uploads `crap-badge.json` as an artifact and a
+separate `badge` job pushes it to a dedicated `badges` branch, so the
+default branch never carries a generated file. See
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) if you want that
+shape instead.
+
 ### PR comment bot
 
 `--format pr-comment` produces a sticky comment that surfaces regressions
@@ -590,6 +669,30 @@ self_score:
             await github.rest.issues.createComment({ ...args, issue_number: context.issue.number });
           }
 ```
+
+## Troubleshooting
+
+**Every function shows `—` or 0% coverage.** Either no `--lcov` was
+passed (see the flag table — that run scores everything as uncovered by
+design), or the LCOV file and the analyzed tree describe different
+scopes. `cargo-crap` detects the second case and prints analyzed / LCOV /
+matched file counts to stderr before the report, with examples of files
+present on only one side; the same numbers are in the `diagnostics`
+object of both JSON envelopes, so CI can gate on them. The usual cause is
+a coverage run scoped to one crate and an analysis scoped to the
+workspace, or vice versa.
+
+**My test helpers are not listed.** They are skipped on purpose — see
+[What gets a score](#what-gets-a-score-and-what-counts-as-complexity).
+
+**CC is higher than another tool reports.** Every `match` arm and every
+`?` counts; the same section explains why.
+
+**`--baseline` reports functions as `removed` that clearly still exist.**
+Baseline entries are filtered through the current run's exclusions before
+comparison, so this is usually a scope change instead: a `-p` subset run
+against a whole-workspace baseline, or an `--exclude` added since. Match
+the scope, or regenerate the baseline once.
 
 ## Prior art and references
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Example output:
 | `--epsilon <VALUE>`                                              | `0.01`        | Tolerance for the regression detector. Score deltas with absolute value at or below this count as `Unchanged`. Set to `0.0` to flag every increase, or higher to tolerate noisy coverage. Must be non-negative.                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `--jobs <N>`                                                     | host CPUs     | Cap parallel source-file analysis at `N` threads. Useful in memory-constrained CI/Docker environments. Must be a positive integer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `--output <FILE>`                                                | —             | Write output to FILE instead of stdout (useful for saving JSON baselines).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `--repo-url <URL>`                                               | —             | Base URL of the source-hosting repo (e.g. `https://github.com/owner/repo`). With `--commit-ref`, makes Function and Location cells in `markdown` / `pr-comment` output clickable links to the source. Defaults from `GITHUB_SERVER_URL` + `GITHUB_REPOSITORY` inside GitHub Actions.                                                                                                                                                                                                                                                                                                              |
+| `--commit-ref <REF>`                                             | —             | Commit SHA or branch to deep-link into. Defaults from `GITHUB_SHA` when set. No effect unless `--repo-url` is also set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 Colour in the `human` and `--summary` formats is automatic: it is enabled only when writing to a terminal, and never into an `--output` file or a pipe. Set `NO_COLOR=1` to disable colour unconditionally, or `FORCE_COLOR=1` to force it on (e.g. for `| less -R`); `NO_COLOR` wins when both are set.
 
@@ -154,7 +156,7 @@ generate types directly from the schema.
 // cargo crap --format json
 {
   "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json",
-  "version": "0.0.2",
+  "version": "0.4.3",     // the cargo-crap version that produced the report
   "entries": [
     {
       "file": "src/lib.rs",
@@ -174,7 +176,7 @@ generate types directly from the schema.
 // cargo crap --format json --baseline baseline.json
 {
   "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json",
-  "version": "0.0.2",
+  "version": "0.4.3",     // the cargo-crap version that produced the report
   "entries": [ /* DeltaEntry — current + baseline_crap + delta + status (+ optional previous_file when moved) */ ],
   "removed": [ /* RemovedEntry — function, file, baseline_crap */ ]
 }
@@ -189,6 +191,28 @@ of files present only on one side. When the analyzed tree and the coverage
 run describe different scopes (the classic cause of a delta full of
 unrelated 0%-coverage entries), a warning with the same numbers is printed
 to stderr before the report, and CI wrappers can gate on the JSON counts.
+
+On `--duplicates` runs both envelopes grow a `duplicates` array — one object
+per candidate pair, in the same order as the human section:
+
+```jsonc
+"duplicates": [
+  {
+    "first_file": "src/report/markdown.rs",
+    "first_function": "write_markdown_absolute_heading",
+    "first_start_line": 18,
+    "first_end_line": 33,
+    "second_file": "src/report/pr_comment.rs",
+    "second_function": "write_pr_comment_delta_headline",
+    "second_start_line": 275,
+    "second_end_line": 286,
+    "score": 0.92          // Jaccard similarity, in [0, 1]
+  }
+]
+```
+
+The key is absent — not empty — when detection was not requested, so "not
+asked" stays distinguishable from "asked, found nothing".
 
 ### SARIF output
 
@@ -216,7 +240,8 @@ normal badge image:
 ![CRAP](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/owner/repo/main/crap-badge.json)
 ```
 
-The label embeds the effective threshold (`CRAP > 15`) so the badge reads
+The label embeds the *effective* threshold — `CRAP > 30` by default, or
+whatever `--threshold` was given (`CRAP > 15` in this repo's own run) — so the badge reads
 as a complete statement. The message is `passing` (brightgreen) when no
 function exceeds `--threshold`, `N crappy` in yellow for 1–5 offenders,
 and red for 6 or more. `--baseline` is silently ignored — the badge
@@ -294,9 +319,12 @@ envelope; the key is absent entirely when detection was not requested, so
 
 ## Configuration file
 
-Any flag can be set persistently in `.cargo-crap.toml` at the project root
+Most flags can be set persistently in `.cargo-crap.toml` at the project root
 (or any parent directory — the tool walks up until it finds one). CLI flags
-always take precedence.
+always take precedence. The per-run selectors have no config key —
+`--path`, `--format`, `--output`, `--summary`, `--workspace`, `-p`/`--package`,
+`--baseline`, `--no-default-excludes`, `--repo-url` and `--commit-ref` are
+flags only. `uncovered-hints` is the mirror case: config only, no flag.
 
 ```toml
 # .cargo-crap.toml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cargo-crap
 
-[![v0.4.3](https://img.shields.io/badge/v0.4.3-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.4.3)
+[![v0.5.0](https://img.shields.io/badge/v0.5.0-2563eb?style=for-the-badge)](https://github.com/minikin/cargo-crap/releases/tag/v0.5.0)
 [![crates.io](https://img.shields.io/badge/crates.io-E57300?style=for-the-badge&logo=rust&logoColor=white)](https://crates.io/crates/cargo-crap)
-[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.4.3/cargo_crap/)
+[![docs.rs](https://img.shields.io/badge/docs.rs-000000?style=for-the-badge&logo=docsdotrs&logoColor=white)](https://docs.rs/cargo-crap/0.5.0/cargo_crap/)
 [![CRAP](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fminikin%2Fcargo-crap%2Fbadges%2Fcrap-badge.json&style=for-the-badge)](https://github.com/minikin/cargo-crap/actions/workflows/ci.yml)
 
 > [!TIP]
@@ -156,7 +156,7 @@ generate types directly from the schema.
 // cargo crap --format json
 {
   "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json",
-  "version": "0.4.3",     // the cargo-crap version that produced the report
+  "version": "0.5.0",     // the cargo-crap version that produced the report
   "entries": [
     {
       "file": "src/lib.rs",
@@ -176,7 +176,7 @@ generate types directly from the schema.
 // cargo crap --format json --baseline baseline.json
 {
   "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/delta-v2.json",
-  "version": "0.4.3",     // the cargo-crap version that produced the report
+  "version": "0.5.0",     // the cargo-crap version that produced the report
   "entries": [ /* DeltaEntry — current + baseline_crap + delta + status (+ optional previous_file when moved) */ ],
   "removed": [ /* RemovedEntry — function, file, baseline_crap */ ]
 }

--- a/schemas/delta-v2.json
+++ b/schemas/delta-v2.json
@@ -28,9 +28,74 @@
     "diagnostics": {
       "$ref": "#/definitions/ScopeDiagnostics",
       "description": "Optional source/LCOV scope diagnostics for the current run (spec 24); absent for complexity-only runs."
+    },
+    "duplicates": {
+      "type": "array",
+      "description": "Candidate duplicate function pairs, ordered by descending score. Present only on `--duplicates` runs; absent — not empty — otherwise, so \"not asked\" stays distinguishable from \"asked, found nothing\".",
+      "items": { "$ref": "#/definitions/DuplicatePair" }
     }
   },
   "definitions": {
+    "DuplicatePair": {
+      "type": "object",
+      "description": "Two functions whose normalized syntax trees are similar enough to be worth review, scored by Jaccard similarity over their subtree fingerprints.",
+      "required": [
+        "first_file",
+        "first_function",
+        "first_start_line",
+        "first_end_line",
+        "second_file",
+        "second_function",
+        "second_start_line",
+        "second_end_line",
+        "score"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "first_file": {
+          "type": "string",
+          "description": "Source file of the side that sorts first."
+        },
+        "first_function": {
+          "type": "string",
+          "description": "Its function name. Methods include the impl-type prefix, e.g. `Foo::bar`."
+        },
+        "first_start_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first line of that function (inclusive)."
+        },
+        "first_end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last line of that function (inclusive)."
+        },
+        "second_file": {
+          "type": "string",
+          "description": "Source file of the side that sorts second."
+        },
+        "second_function": {
+          "type": "string",
+          "description": "Its function name. Methods include the impl-type prefix, e.g. `Foo::bar`."
+        },
+        "second_start_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first line of that function (inclusive)."
+        },
+        "second_end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last line of that function (inclusive)."
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Jaccard similarity of the two fingerprint sets, in [0, 1]."
+        }
+      }
+    },
     "DeltaEntry": {
       "type": "object",
       "description": "A `CrapEntry` (flattened) plus delta-mode fields.",

--- a/schemas/report-v1.json
+++ b/schemas/report-v1.json
@@ -25,9 +25,74 @@
     "diagnostics": {
       "$ref": "#/definitions/ScopeDiagnostics",
       "description": "Optional source/LCOV scope diagnostics (spec 24); absent for complexity-only runs."
+    },
+    "duplicates": {
+      "type": "array",
+      "description": "Candidate duplicate function pairs, ordered by descending score. Present only on `--duplicates` runs; absent — not empty — otherwise, so \"not asked\" stays distinguishable from \"asked, found nothing\".",
+      "items": { "$ref": "#/definitions/DuplicatePair" }
     }
   },
   "definitions": {
+    "DuplicatePair": {
+      "type": "object",
+      "description": "Two functions whose normalized syntax trees are similar enough to be worth review, scored by Jaccard similarity over their subtree fingerprints.",
+      "required": [
+        "first_file",
+        "first_function",
+        "first_start_line",
+        "first_end_line",
+        "second_file",
+        "second_function",
+        "second_start_line",
+        "second_end_line",
+        "score"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "first_file": {
+          "type": "string",
+          "description": "Source file of the side that sorts first."
+        },
+        "first_function": {
+          "type": "string",
+          "description": "Its function name. Methods include the impl-type prefix, e.g. `Foo::bar`."
+        },
+        "first_start_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first line of that function (inclusive)."
+        },
+        "first_end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last line of that function (inclusive)."
+        },
+        "second_file": {
+          "type": "string",
+          "description": "Source file of the side that sorts second."
+        },
+        "second_function": {
+          "type": "string",
+          "description": "Its function name. Methods include the impl-type prefix, e.g. `Foo::bar`."
+        },
+        "second_start_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed first line of that function (inclusive)."
+        },
+        "second_end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed last line of that function (inclusive)."
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Jaccard similarity of the two fingerprint sets, in [0, 1]."
+        }
+      }
+    },
     "CrapEntry": {
       "type": "object",
       "required": ["file", "function", "line", "cyclomatic", "coverage", "crap"],

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,9 +21,22 @@
 //! sort = "file"
 //! # Show Unchanged rows in --baseline mode (human / markdown).
 //! show_unchanged = true
+//! # Hide entries scoring below this; keep only the N worst offenders.
+//! min = 5.0
+//! top = 20
+//! # Exit 1 when any score rises against --baseline.
+//! fail-regression = true
+//! # Regression-detector tolerance, and a cap on analysis threads.
+//! epsilon = 0.01
+//! jobs = 4
 //! # Append an Uncovered column (uncovered line ranges) to the human,
 //! # markdown, and pr-comment outputs.
 //! uncovered-hints = true
+//! # Structural duplicate detection (--duplicates).
+//! [duplicates]
+//! enabled = false
+//! threshold = 0.82
+//! min-nodes = 20
 //! ```
 
 use crate::merge::{MissingCoveragePolicy, SortOrder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,8 @@
 //! | [`coverage`] | LCOV parser. Produces `(file, line) → hit-count` maps. |
 //! | [`merge`] | Joins complexity with coverage. Handles all path-matching cases. |
 //! | [`delta`] | Baseline comparison. Computes per-function deltas and regression counts. |
-//! | [`report`] | Renders `Vec<CrapEntry>` or `DeltaReport` as human table, JSON, GitHub annotations, or Markdown. |
+//! | [`duplicates`] | Structural duplicate detection: normalize each function's AST, fingerprint its subtrees, compare pairs by Jaccard similarity. |
+//! | [`report`] | Renders `Vec<CrapEntry>` or `DeltaReport` as a human table, JSON, GitHub annotations, Markdown, a PR comment, SARIF, or a Shields.io badge. |
 //! | [`config`] | Loads `.cargo-crap.toml` by walking up from CWD. |
 
 pub mod complexity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ struct Cli {
     #[arg(long)]
     threshold: Option<f64>,
 
-    /// Only print functions with a CRAP score above this cutoff.
+    /// Only print functions with a CRAP score at or above this cutoff.
     #[arg(long, value_name = "SCORE")]
     min: Option<f64>,
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -281,6 +281,103 @@ fn delta_json_output_validates_against_delta_schema() {
     assert_valid(&validator, &value);
 }
 
+/// A tree holding two functions that differ only in names, bindings and
+/// literal values — an exact structural match for `--duplicates`.
+fn duplicate_tree() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("alpha.rs"),
+        "fn alpha(xs: &[i32]) -> Vec<i32> {
+    let mut ys = Vec::new();
+    for x in xs {
+        if x % 2 == 1 {
+            ys.push(x + 1);
+        }
+    }
+    ys
+}
+",
+    )
+    .expect("write alpha.rs");
+    std::fs::write(
+        dir.path().join("beta.rs"),
+        "fn beta(items: &[i32]) -> Vec<i32> {
+    let mut kept = Vec::new();
+    for item in items {
+        if item % 2 == 0 {
+            kept.push(item + 1);
+        }
+    }
+    kept
+}
+",
+    )
+    .expect("write beta.rs");
+    dir
+}
+
+#[test]
+fn duplicates_json_output_validates_against_published_schema() {
+    let dir = duplicate_tree();
+    let output = cmd()
+        .arg("--path")
+        .arg(dir.path())
+        .arg("--duplicates")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert!(
+        !value["duplicates"]
+            .as_array()
+            .expect("duplicates array")
+            .is_empty(),
+        "fixture must produce at least one pair:\n{stdout}"
+    );
+    let validator = compile_schema("schemas/report-v1.json");
+    assert_valid(&validator, &value);
+}
+
+#[test]
+fn duplicates_delta_json_output_validates_against_delta_schema() {
+    let dir = duplicate_tree();
+    let baseline_dir = tempfile::tempdir().expect("tempdir");
+    let baseline_path = baseline_dir.path().join("baseline.json");
+    cmd()
+        .arg("--path")
+        .arg(dir.path())
+        .arg("--format")
+        .arg("json")
+        .arg("--output")
+        .arg(&baseline_path)
+        .assert()
+        .success();
+
+    let output = cmd()
+        .arg("--path")
+        .arg(dir.path())
+        .arg("--baseline")
+        .arg(&baseline_path)
+        .arg("--duplicates")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("delta run");
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert!(
+        !value["duplicates"]
+            .as_array()
+            .expect("duplicates array")
+            .is_empty(),
+        "fixture must produce at least one pair:\n{stdout}"
+    );
+    let validator = compile_schema("schemas/delta-v2.json");
+    assert_valid(&validator, &value);
+}
+
 // --- --fail-above ---
 
 #[test]


### PR DESCRIPTION
Cuts **0.5.0**: two features merged since v0.4.3, one schema bug found while
preparing the release, and the backlog from a documentation audit.

## Release contents

| Spec | What |
| --- | --- |
| 29 (#79) | Structural duplicate detection — `--duplicates`, `--dup-threshold`, `[duplicates]` config |
| 28 (#75) | Uncovered-span hints — `uncovered` in JSON, optional `Uncovered` column via `uncovered-hints` |
| — | A real delta is never displayed as `±0.0` |
| 22 (#76) | CI pins the self-score baseline to the merge base (internal) |

Spec 27 is still `Proposed` and is not in this release.

Minor bump: additive for JSON and config consumers, breaking only for library
code that builds `RenderOptions` or `CrapEntry` with an exhaustive struct
literal — both gained fields. The changelog's Changed section has the
one-line migration.

## Release blocker found and fixed (`e180a0e`)

`--duplicates` made both envelopes emit a top-level `duplicates` array that
neither published schema declared, and both schemas set
`"additionalProperties": false`. So the validation step the README tells
consumers to run failed on the tool's own output:

```
Additional properties are not allowed ('duplicates' was unexpected)
```

Spec 29's JSON scenario asked only that the document be valid JSON, and the
existing schema tests only covered runs *without* `--duplicates` — that is how
it got through. Fixed test-first: two failing regression tests in
`tests/cli.rs` (absolute + delta envelope), then a `DuplicatePair` definition
in both schemas. Additive and optional, so documents from earlier releases stay
valid and neither envelope version moves.

## Documentation audit (`4108cbe`, `8ebb9ab`)

Every doc was checked against the source. 26 findings fixed; each claim was
verified before the fix.

**Wrong** — README JSON samples showed `"version": "0.0.2"` (the field is
`env!("CARGO_PKG_VERSION")`); `--repo-url` / `--commit-ref` appeared in no
table anywhere; "Any flag can be set persistently" (ten flags have no config
key, and `uncovered-hints` has no flag); the Shields label illustration used
this repo's threshold 15 where the default is 30; CONTRIBUTING's MSRV read 1.85
against `rust-version = "1.88"`; the binstall comment contradicted the
`pkg-url` two lines below it; `--min` help said "above this cutoff" where the
filter is `crap >= min`; the sample human table used the wrong box-drawing
characters; `src/lib.rs` and CLAUDE.md both predated `src/duplicates/` and
still counted four output formats.

**Missing** — a section on what actually gets scored and what counts as a
decision point (test code is never scored; every `match` arm and every `?`
counts, so a three-arm `match` is CC 4 where textbook McCabe says 3 — the
top "why is my number different?" question); a Troubleshooting section; a
flag ↔ config-key table; `cargo install cargo-llvm-cov` in Quick start; what
omitting `--lcov` actually does; the `min` / `top` / `fail-regression` /
`epsilon` / `jobs` / `[duplicates]` config keys; CHANGELOG version links.

## Left open — needs a maintainer decision

- `CODE_OF_CONDUCT.md:63` — the enforcement contact is a bare `.`.
- `crap-baseline.json` is documented as committed to the repo, but is not
  tracked and does not exist, so `just crap-delta` and `just keeler-branch`
  fail immediately. Either commit a baseline or correct the doc.
- The 90% line-coverage bar is enforced nowhere: `just cov` has it, `dev` does
  not call `cov`, and CI has no `fail-under`. The misleading `dev` comment is
  fixed; CLAUDE.md's "ci.yml already runs every Keeler gate" stays true only
  once this is decided.

## Gates

- `just dev` — clean (581 tests; 246 functions, none above threshold 15)
- `just mutants-diff` — clean (193 mutants: 149 caught, 44 unviable, **0 survivors**)
- `cargo publish --dry-run` — packages 0.5.0 successfully
- README anchors and relative links all resolve

After merge: tag `v0.5.0` to trigger the release workflow.